### PR TITLE
Remove obsolete git add from lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,8 +126,7 @@
   },
   "lint-staged": {
     "*": [
-      "prettier --write --ignore-unknown",
-      "git add"
+      "prettier --write --ignore-unknown"
     ]
   },
   "main": "dist/main.js",


### PR DESCRIPTION
It is not needed since lint-staged 10.0 and warns about it since a few versions ago
