### PR TITLE
Improve GitHub Workflows with forks support and linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Lint code
+        run: npm run lint:ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Lint code
+        run: npm run lint:ci

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start:prod": "node dist/main",
     "deploy:demo": "pm2 deploy demo-ecosystem.config.js production update",
     "lint": "eslint \"{src,scripts,test,@types}/**/*.ts\" --fix",
+    "lint:ci": "eslint \"{src,scripts,test,@types}/**/*.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
- Leave GitHub Actions checkout ref by default
- Lint code in CI without fixingit, but just reporting violations
