### PR TITLE
Fix seeds first run

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postbuild": "cp -r src/seeds/parl-2021-04-04 dist/seeds/",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
+    "prestart:dev": "mkdir -p dist/seeds && cp -r src/seeds/parl-2021-04-04 dist/seeds/",
     "start:dev": "nest start --watch",
     "start:dev:db": "./scripts/start-dev-db.sh",
     "start:debug": "nest start --debug --watch",

--- a/src/seeds/1616992561879-AddStreams.ts
+++ b/src/seeds/1616992561879-AddStreams.ts
@@ -1,18 +1,23 @@
-import { csvToSql } from 'src/utils/csvToSql';
+import * as fs from 'fs';
 import { MigrationInterface, QueryRunner } from 'typeorm';
 import { ulid } from 'ulid';
+import { csvToSql } from 'src/utils/csvToSql';
 
 export class AddStreams1616992561879 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    (
-      await csvToSql(__dirname + '/parl-2021-04-04/streams.csv', 'streams', {
-        emptyColumnCallback: () => {
-          return ulid();
-        },
-      })
-    )
-      .split(';')
-      .map(async (sql) => await queryRunner.query(sql));
+    const streamsInput = __dirname + '/parl-2021-04-04/streams.csv';
+    if (!fs.existsSync(streamsInput)) {
+      console.warn(`Missing streams seed input: ${streamsInput}`);
+      return;
+    }
+
+    const sql = await csvToSql(streamsInput, 'streams', {
+      emptyColumnCallback: () => {
+        return ulid();
+      },
+    });
+
+    sql.split(';').forEach(async (sql) => await queryRunner.query(sql));
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Какво променя този PR?

Подобрява първоначалния setup при пускането на seeds.

## Детайли

Преди имаше проблем, тъй като не се копираше seeds папката в dist освен ако не се пусне `npm run build`, за да стартира `postbuild` скрипта.

Seed-а за видеостриймовете даваше грешка, ако липсват CSV данните. Сега само показва warning.

## Списък:

- [x] Copy seeds before starting dev watching
- [x] Instruct streams seed to just warn on missing input seed data from the CSV file