### PR TITLE
Номенклатурни кодове на градовете вместо вътрешни идентификатори

### DIFF
--- a/src/sections/api/town-exists.constraint.ts
+++ b/src/sections/api/town-exists.constraint.ts
@@ -16,20 +16,20 @@ export class IsTownExistsConstraint implements ValidatorConstraintInterface {
     @Inject(TownsRepository) private readonly repo: TownsRepository,
   ) {}
 
-  async validate(townId?: number): Promise<boolean> {
-    if (!townId) {
+  async validate(townCode?: number): Promise<boolean> {
+    if (!townCode) {
       return true;
     }
 
-    if (typeof townId !== 'number' || townId <= 0) {
+    if (typeof townCode !== 'number' || townCode <= 0) {
       return false;
     }
 
-    return !!(await this.repo.findOne(townId));
+    return !!(await this.repo.findOneByCode(townCode));
   }
 
   defaultMessage?(validationArguments?: ValidationArguments): string {
-    return `Town with ID "${validationArguments.value}" does not exist!`;
+    return `Town with code "${validationArguments.value}" does not exist!`;
   }
 }
 

--- a/src/sections/api/town.dto.ts
+++ b/src/sections/api/town.dto.ts
@@ -11,7 +11,7 @@ import { IsTownExists } from './town-exists.constraint';
 @Exclude()
 export class TownDto {
   @ApiProperty()
-  @Expose({ groups: ['read', 'create'] })
+  @Expose({ name: 'code', groups: ['read', 'create'] })
   @IsTownExists({ groups: ['create'] })
   @IsNumber({}, { groups: ['create'] })
   @Min(1, { groups: ['create'] })

--- a/src/sections/entities/sections.repository.ts
+++ b/src/sections/entities/sections.repository.ts
@@ -39,7 +39,7 @@ export class SectionsRepository {
   }
 
   findByTownAndCityRegion(
-    townId: number,
+    townCode: number,
     cityRegionCode?: string,
   ): Promise<Section[]> {
     return this.repo.find({
@@ -50,7 +50,7 @@ export class SectionsRepository {
         },
       },
       where: (qb: SelectQueryBuilder<Section>): void => {
-        qb.where({ town: townId });
+        qb.andWhere('town.code = :townCode', { townCode });
 
         if (cityRegionCode) {
           qb.innerJoinAndSelect(

--- a/src/sections/entities/towns.repository.ts
+++ b/src/sections/entities/towns.repository.ts
@@ -10,12 +10,12 @@ export class TownsRepository {
     private repo: Repository<Town>,
   ) {}
 
-  findOne(id: number): Promise<Town> {
-    return this.repo.findOne(id);
+  findOneByCode(code: number): Promise<Town> {
+    return this.repo.findOne({ code });
   }
 
-  findOneOrFail(id: number): Promise<Town> {
-    return this.repo.findOneOrFail(id);
+  findOneByCodeOrFail(code: number): Promise<Town> {
+    return this.repo.findOneOrFail({ code });
   }
 
   filter(

--- a/src/violations/api/violations-filters.dto.ts
+++ b/src/violations/api/violations-filters.dto.ts
@@ -16,7 +16,7 @@ export class ViolationsFilters extends PageDTO {
   author: string;
 
   @Optional()
-  town: string;
+  town: number;
 
   @Optional()
   organization: number;

--- a/src/violations/entities/violations.repository.ts
+++ b/src/violations/entities/violations.repository.ts
@@ -57,7 +57,7 @@ export class ViolationsRepository {
     }
 
     if (filters.town) {
-      qb.andWhere('town.id = :town', { town: filters.town });
+      qb.andWhere('town.code = :town', { town: filters.town });
     }
 
     if (filters.author || filters.organization) {


### PR DESCRIPTION
## Какво променя този PR?

Градовете са едно от последните неща от локациите и секциите, за които в публичния интерфейс (REST API) не използваме познати публични кодове, а всъщност разкривахме вътрешни идентификатори.

## Детайли

Това всъщност въвежда използването на [ЕКАТТЕ кодовете на градовете в България](https://bg.m.wikipedia.org/wiki/%D0%95%D0%9A%D0%90%D0%A2%D0%A2%D0%95) и би позволило синхронизация и на кодовете на градовете в чужбина.

Това би улеснило няколко неща в бъдеще:

✅  Консистентност - всички endpoints свързани със секциите ще използват външно познати идентификатори.
✅  Консистентност - и резултатите и endpoints за секции и други за филтри в админа ще ползват едни и същи идентификатори. Досега само резултатите използваха ЕКАТТЕ кодовете на градовете.
✅  Интеграции - По този начин можем да се интегрираме по-лесно с външни системи и за търсене на секции и подаване на протоколи и резултати без да има нужда да обменяме предварително наши вътрешни идентификатори. Всеки може да ползва ЕКАТТЕ идентификаторите.
✅ Разследване / debugging - при дебъгване между мобилните приложения и API-то или преброителният център и API-то или резултатите и API-то, това ще улесни дебъгването и защото е консистентно, но и защото кодовете са постоянни и ще може да се реферират и от юристи и други независимо дали се нулира и построява базата данни с градовете наново или се променят входните данни за секциите.

## Списък:

- [x] Промяна на сериализацията и десериализацията на градовете
- [x] Промяна на търсенето по град при валидация на кода на града (създаване на сигнал)
- [x] Промяна при търсенето на секции по град

<!-- Опишете всичките компоненти на промените и отбележете кои са готови и кои предстоят. -->

## Бележки за deployment и breaking changes

❗ Важно е да се отбележи, че това не е breaking change и няма да счупи нищо, тъй като в API-то продължава да се използва единствено и само town.id като референция и типа на данните и същия.

❗ Също вече имаме индекс по код на града и тъй като типа и кардиналността на колоната са същите няма да има разлика в скоростта на изпълнение.