### PR TITLE
Филтри за сигналите в преброителния център

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,54 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-inferrable-types': 'off',
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          String: {
+            message: 'Use string instead',
+            fixWith: 'string',
+          },
+          Boolean: {
+            message: 'Use boolean instead',
+            fixWith: 'boolean',
+          },
+          Number: {
+            message: 'Use number instead',
+            fixWith: 'number',
+          },
+          Symbol: {
+            message: 'Use symbol instead',
+            fixWith: 'symbol',
+          },
+
+          Function: {
+            message: [
+              'The `Function` type accepts any function-like value.',
+              'It provides no type safety when calling the function, which can be a common source of bugs.',
+              'It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.',
+              'If you are expecting the function to accept certain arguments, you should explicitly define the function shape.',
+            ].join('\n'),
+          },
+
+          // object typing
+          Object: {
+            message: [
+              'The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
+              '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
+              '- If you want a type meaning "any value", you probably want `unknown` instead.',
+            ].join('\n'),
+          },
+          '{}': {
+            message: [
+              '`{}` actually means "any non-nullish value".',
+              '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
+              '- If you want a type meaning "any value", you probably want `unknown` instead.',
+            ].join('\n'),
+          },
+          object: false,
+        },
+      },
+    ],
   },
 };

--- a/src/i18n/bg/status.json
+++ b/src/i18n/bg/status.json
@@ -13,5 +13,6 @@
   "BROADCAST_PENDING": "В изчакване",
   "BROADCAST_PROCESSING": "Обработва се",
   "BROADCAST_PUBLISHED": "Публикувано",
-  "BROADCAST_DISCARDED": "Отхвърлено"
+  "BROADCAST_DISCARDED": "Отхвърлено",
+  "OBJECT_ACCEPTED": "Прието"
 }

--- a/src/i18n/en/status.json
+++ b/src/i18n/en/status.json
@@ -13,5 +13,6 @@
   "BROADCAST_PENDING": "Pending",
   "BROADCAST_PROCESSING": "Processing",
   "BROADCAST_PUBLISHED": "Published",
-  "BROADCAST_DISCARDED": "Discarded"
+  "BROADCAST_DISCARDED": "Discarded",
+  "OBJECT_ACCEPTED": "Accepted"
 }

--- a/src/migrations/1624337501383-AddTownsCountryMunicipalityIndices.ts
+++ b/src/migrations/1624337501383-AddTownsCountryMunicipalityIndices.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTownsCountryMunicipalityIndices1624337501383
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        create index "towns_country_id_key" on "towns" ("country_id");
+        create index "towns_municipality_id_key" on "towns" ("country_id");
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        drop index "towns_municipality_id_key";
+        drop index "towns_country_id_key";
+      `);
+  }
+}

--- a/src/sections/api/town-exists.constraint.ts
+++ b/src/sections/api/town-exists.constraint.ts
@@ -34,7 +34,7 @@ export class IsTownExistsConstraint implements ValidatorConstraintInterface {
 }
 
 export function IsTownExists(validationOptions?: ValidationOptions) {
-  return function (town: TownDto, propertyName: string) {
+  return function (town: TownDto | object, propertyName: string) {
     registerDecorator({
       target: town.constructor,
       propertyName: propertyName,

--- a/src/sections/api/town.dto.ts
+++ b/src/sections/api/town.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Exclude, Expose, plainToClass, Type } from 'class-transformer';
+import {
+  Exclude,
+  Expose,
+  plainToClass,
+  Transform,
+  Type,
+} from 'class-transformer';
 import { IsInt, IsNotEmpty, IsNumber, Min } from 'class-validator';
 import { StreamDto } from 'src/streams/api/stream.dto';
 import { Town } from '../entities';

--- a/src/sections/api/town.dto.ts
+++ b/src/sections/api/town.dto.ts
@@ -1,11 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  Exclude,
-  Expose,
-  plainToClass,
-  Transform,
-  Type,
-} from 'class-transformer';
+import { Exclude, Expose, plainToClass, Type } from 'class-transformer';
 import { IsInt, IsNotEmpty, IsNumber, Min } from 'class-validator';
 import { StreamDto } from 'src/streams/api/stream.dto';
 import { Town } from '../entities';

--- a/src/sections/entities/town.entity.ts
+++ b/src/sections/entities/town.entity.ts
@@ -19,7 +19,7 @@ export class Town {
   readonly id: number;
 
   @Column()
-  readonly code: number;
+  code: number;
 
   @Column()
   readonly name: string;

--- a/src/sections/sections.module.ts
+++ b/src/sections/sections.module.ts
@@ -54,6 +54,7 @@ import { CityRegionsRepository } from './entities/cityRegions.repository';
     MunicipalitiesRepository,
     CountriesRepository,
     CityRegionsRepository,
+    TownsRepository,
   ],
   controllers: [
     SectionsController,

--- a/src/users/api/organization-exists.constraint.ts
+++ b/src/users/api/organization-exists.constraint.ts
@@ -32,7 +32,7 @@ export class IsOrganizationExistsConstraint
 }
 
 export function IsOrganizationExists(validationOptions?: ValidationOptions) {
-  return function (object: OrganizationDto, propertyName: string) {
+  return function (object: OrganizationDto | object, propertyName: string) {
     registerDecorator({
       target: object.constructor,
       propertyName: propertyName,

--- a/src/users/api/user-exists.constraint.ts
+++ b/src/users/api/user-exists.constraint.ts
@@ -24,14 +24,14 @@ export class IsUserExistsConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage?(): string {
-    return `User with $property "$value" does not exist!`;
+    return `User with ID "$value" does not exist!`;
   }
 }
 
 export function IsUserExists(validationOptions?: ValidationOptions) {
-  return function (user: UserDto, propertyName: string) {
+  return function (target: UserDto | object, propertyName: string) {
     registerDecorator({
-      target: user.constructor,
+      target: target.constructor,
       propertyName: propertyName,
       options: validationOptions,
       constraints: [],

--- a/src/utils/ulid-constraint.ts
+++ b/src/utils/ulid-constraint.ts
@@ -1,0 +1,33 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ async: true })
+@Injectable()
+export class IsULIDConstraint implements ValidatorConstraintInterface {
+  async validate(id?: string): Promise<boolean> {
+    return typeof id === 'string' && /[A-Z0-9]{26}/.test(id);
+  }
+
+  defaultMessage?(context: ValidationArguments): string {
+    console.debug(context.object);
+    return `${context.property} identifier is not an ULID`;
+  }
+}
+
+export function IsULID(validationOptions?: ValidationOptions) {
+  return function (entity: object, propertyName: string) {
+    registerDecorator({
+      target: entity.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsULIDConstraint,
+    });
+  };
+}

--- a/src/utils/ulid-constraint.ts
+++ b/src/utils/ulid-constraint.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import {
   registerDecorator,
   ValidationArguments,

--- a/src/violations/api/violation.dto.ts
+++ b/src/violations/api/violation.dto.ts
@@ -46,7 +46,8 @@ export class ViolationDto {
   @Expose({ groups: ['read', 'create'] })
   @Type(() => TownDto)
   @Transform(
-    ({ value: id }) => plainToClass(TownDto, { id }, { groups: ['create'] }),
+    ({ value: id }) =>
+      plainToClass(TownDto, { code: id }, { groups: ['create'] }),
     { groups: ['create'] },
   )
   @IsNotEmpty({ groups: ['create'] })
@@ -111,6 +112,7 @@ export class ViolationDto {
         groups: ['create'],
       },
     );
+    violation.town.code = this.town.id;
 
     let sortPosition = 1;
     violation.pictures = (violation.pictures || []).map(

--- a/src/violations/api/violations-filters.dto.ts
+++ b/src/violations/api/violations-filters.dto.ts
@@ -13,11 +13,23 @@ export class ViolationsFilters extends PageDTO {
   status: ViolationStatus;
 
   @Optional()
-  author: string;
+  electionRegion: string;
+
+  @Optional()
+  municipality: string;
+
+  @Optional()
+  country: string;
 
   @Optional()
   town: number;
 
   @Optional()
+  cityRegion: string;
+
+  @Optional()
   organization: number;
+
+  @Optional()
+  published: boolean;
 }

--- a/src/violations/api/violations-filters.dto.ts
+++ b/src/violations/api/violations-filters.dto.ts
@@ -1,9 +1,7 @@
 import { Type } from 'class-transformer';
 import {
-  IsBoolean,
   IsBooleanString,
   IsInt,
-  IsNumber,
   IsNumberString,
   IsOptional,
   Length,

--- a/src/violations/api/violations-filters.dto.ts
+++ b/src/violations/api/violations-filters.dto.ts
@@ -1,35 +1,64 @@
-import { Optional } from '@nestjs/common';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsBooleanString,
+  IsInt,
+  IsNumber,
+  IsNumberString,
+  IsOptional,
+  Length,
+} from 'class-validator';
+import { IsTownExists } from 'src/sections/api/town-exists.constraint';
+import { IsOrganizationExists } from 'src/users/api/organization-exists.constraint';
+import { IsUserExists } from 'src/users/api/user-exists.constraint';
 import { PageDTO } from 'src/utils/page.dto';
+import { IsULID } from 'src/utils/ulid-constraint';
 import { ViolationStatus } from '../entities/violation.entity';
 
 export class ViolationsFilters extends PageDTO {
-  @Optional()
+  @IsOptional()
+  @IsULID()
+  @IsUserExists()
   assignee: string;
 
-  @Optional()
+  @IsOptional()
+  @Length(1, 9)
   section: string;
 
-  @Optional()
+  @IsOptional()
   status: ViolationStatus;
 
-  @Optional()
+  @IsOptional()
+  @IsNumberString()
+  @Length(2, 2)
   electionRegion: string;
 
-  @Optional()
+  @IsOptional()
+  @IsNumberString()
+  @Length(2, 2)
   municipality: string;
 
-  @Optional()
+  @IsOptional()
+  @IsNumberString()
+  @Length(2, 2)
   country: string;
 
-  @Optional()
+  @IsOptional()
+  @IsTownExists()
   town: number;
 
-  @Optional()
+  @IsOptional()
+  @IsNumberString()
+  @Length(2, 2)
   cityRegion: string;
 
-  @Optional()
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  @IsOrganizationExists()
   organization: number;
 
-  @Optional()
+  @IsOptional()
+  @IsBooleanString()
   published: boolean;
 }

--- a/src/violations/api/violations.controller.ts
+++ b/src/violations/api/violations.controller.ts
@@ -38,7 +38,7 @@ export class ViolationsController {
   @Get()
   @HttpCode(200)
   @UseGuards(PoliciesGuard)
-  @CheckPolicies((ability: Ability) => ability.can(Action.Read, Violation))
+  @CheckPolicies((ability: Ability) => ability.can(Action.Manage, Violation))
   @UsePipes(new ValidationPipe({ transform: true }))
   async index(
     @Query() query: ViolationsFilters,

--- a/src/violations/entities/violations.repository.ts
+++ b/src/violations/entities/violations.repository.ts
@@ -35,9 +35,13 @@ export class ViolationsRepository {
     const qb = this.repo.createQueryBuilder('violation');
 
     qb.innerJoinAndSelect('violation.town', 'town');
-    qb.innerJoinAndSelect('violation.updates', 'update');
-    qb.innerJoinAndSelect('update.actor', 'actor');
-    qb.innerJoinAndSelect('actor.organization', 'organization');
+    qb.innerJoinAndSelect('violation.updates', 'update_send');
+    qb.andWhere('update_send.type = :update', {
+      update: ViolationUpdateType.SEND,
+    });
+    qb.innerJoinAndSelect('update_send.actor', 'sender');
+    qb.innerJoinAndSelect('sender.organization', 'organization');
+    qb.innerJoinAndSelect('violation.updates', 'updates');
     qb.leftJoinAndSelect('violation.pictures', 'picture');
 
     if (filters.assignee) {
@@ -92,12 +96,6 @@ export class ViolationsRepository {
     }
 
     if (filters.organization) {
-      qb.innerJoin('violation.updates', 'update_send');
-      qb.andWhere('update_send.type = :update', {
-        update: ViolationUpdateType.SEND,
-      });
-      qb.innerJoin('update_send.actor', 'sender');
-      qb.innerJoin('sender.organization', 'organization');
       qb.andWhere('organization.id = :organization', {
         organization: filters.organization,
       });

--- a/src/violations/violations.module.ts
+++ b/src/violations/violations.module.ts
@@ -11,6 +11,7 @@ import { ViolationUpdate } from './entities/violation-update.entity';
 import { Violation } from './entities/violation.entity';
 import { ViolationsRepository } from './entities/violations.repository';
 import { UsersModule } from 'src/users/users.module';
+import { SectionsModule } from 'src/sections/sections.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { UsersModule } from 'src/users/users.module';
     CaslModule,
     PicturesModule,
     UsersModule,
+    SectionsModule,
   ],
   controllers: [
     ViolationsController,


### PR DESCRIPTION
## Какво променя този PR?

Предоставя филтри в API-то за сигналите, които могат да се използват от клиента на преброителния център.

## Детайли

Добавя всички филтри нужни за https://github.com/ti-broish/admin/issues/33 и оправя няколко неща като валидации и достъп до списъка с филтри.

## Списък:

- [x] Оправя проблем с градовете при създаване на сигнал
- [x] Добавяне на всички филтри за сигнали
- [x] Валидация на филтрите за сигналите
