### PR TITLE
Generate correct links in pagination with query params

### DIFF
--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -13,8 +13,9 @@ import {
   Query,
   Res,
   HttpStatus,
+  Request,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Request as ExpressRequest, Response } from 'express';
 import { paginate, Pagination } from 'nestjs-typeorm-paginate';
 import { Action } from 'src/casl/action.enum';
 import { CheckPolicies } from 'src/casl/check-policies.decorator';
@@ -44,6 +45,7 @@ import {
   ACCEPTED_RESPONSE_STATUS,
 } from '../../utils/accepted-response';
 import { BadRequestException } from '@nestjs/common';
+import { paginationRoute } from 'src/utils/pagination-route';
 
 @Controller('protocols')
 export class ProtocolsController {
@@ -64,6 +66,7 @@ export class ProtocolsController {
   @UsePipes(new ValidationPipe({ transform: true }))
   async index(
     @Query() query: ProtocolFilters,
+    @Request() req: ExpressRequest,
   ): Promise<Pagination<ProtocolDto>> {
     let protocolsQb: SelectQueryBuilder<Protocol>;
     try {
@@ -77,7 +80,7 @@ export class ProtocolsController {
     const pagination = await paginate(protocolsQb, {
       page: query.page,
       limit: 100,
-      route: '/protocols',
+      route: paginationRoute(req),
     });
 
     return new Pagination<ProtocolDto>(

--- a/src/users/api/users.controller.ts
+++ b/src/users/api/users.controller.ts
@@ -14,13 +14,16 @@ import {
   Query,
   Patch,
   Param,
+  Request,
 } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { paginate, Pagination } from 'nestjs-typeorm-paginate';
 import { Action } from 'src/casl/action.enum';
 import { CheckPolicies } from 'src/casl/check-policies.decorator';
 import { PoliciesGuard } from 'src/casl/policies.guard';
 import { FirebaseUser } from 'src/firebase';
 import { PageDTO } from 'src/utils/page.dto';
+import { paginationRoute } from 'src/utils/pagination-route';
 import {
   AllowOnlyFirebaseUser,
   InjectFirebaseUser,
@@ -92,13 +95,16 @@ export class UsersController {
   @UseGuards(PoliciesGuard)
   @CheckPolicies((ability: Ability) => ability.can(Action.Manage, User))
   @UsePipes(new ValidationPipe({ transform: true }))
-  async index(@Query() query: UsersFilters): Promise<Pagination<UserDto>> {
+  async index(
+    @Query() query: UsersFilters,
+    @Request() req: ExpressRequest,
+  ): Promise<Pagination<UserDto>> {
     const pagination = await paginate(
       this.repo.queryBuilderWithFilters(query),
       {
         page: query.page,
         limit: 20,
-        route: '/users',
+        route: paginationRoute(req),
       },
     );
 

--- a/src/utils/pagination-route.ts
+++ b/src/utils/pagination-route.ts
@@ -1,0 +1,22 @@
+import { Request } from 'express';
+import url from 'url';
+
+const PAGE_PARAM = 'page';
+
+export function paginationRoute(
+  req: Request,
+  pageParam: string = PAGE_PARAM,
+): string {
+  const parsedUrl = new URL(
+    req.originalUrl,
+    req.protocol + '://' + req.hostname,
+  );
+
+  if (parsedUrl.searchParams.has(pageParam)) {
+    parsedUrl.searchParams.delete(pageParam);
+  }
+
+  const queryString = parsedUrl.searchParams.toString();
+
+  return parsedUrl.pathname + (queryString ? '?' + queryString : '');
+}

--- a/src/violations/api/violation-comments.controller.ts
+++ b/src/violations/api/violation-comments.controller.ts
@@ -11,12 +11,15 @@ import {
   Inject,
   UseGuards,
   Query,
+  Request,
 } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { paginate, Pagination } from 'nestjs-typeorm-paginate';
 import { Action } from 'src/casl/action.enum';
 import { CheckPolicies } from 'src/casl/check-policies.decorator';
 import { PoliciesGuard } from 'src/casl/policies.guard';
 import { PageDTO } from 'src/utils/page.dto';
+import { paginationRoute } from 'src/utils/pagination-route';
 import { InjectUser } from '../../auth/decorators/inject-user.decorator';
 import { User } from '../../users/entities';
 import { ViolationComment } from '../entities/violation-comment.entity';
@@ -42,6 +45,7 @@ export class ViolationCommentsController {
   async index(
     @Query() query: PageDTO,
     @Param('violation') violationId: string,
+    @Request() req: ExpressRequest,
   ): Promise<Pagination<ViolationCommentDto>> {
     const violation = await this.violationsRepo.findOneOrFail(violationId);
     const pagination = await paginate(
@@ -49,7 +53,7 @@ export class ViolationCommentsController {
       {
         page: query.page,
         limit: 20,
-        route: `/violations/${violationId}/comments`,
+        route: paginationRoute(req),
       },
     );
 

--- a/src/violations/api/violations.controller.ts
+++ b/src/violations/api/violations.controller.ts
@@ -12,12 +12,15 @@ import {
   UseGuards,
   Query,
   Patch,
+  Request,
 } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { paginate, Pagination } from 'nestjs-typeorm-paginate';
 import { Action } from 'src/casl/action.enum';
 import { CheckPolicies } from 'src/casl/check-policies.decorator';
 import { PoliciesGuard } from 'src/casl/policies.guard';
 import { UserDto } from 'src/users/api/user.dto';
+import { paginationRoute } from 'src/utils/pagination-route';
 import { InjectUser } from '../../auth/decorators/inject-user.decorator';
 import { PictureDto } from '../../pictures/api/picture.dto';
 import { PicturesUrlGenerator } from '../../pictures/pictures-url-generator.service';
@@ -42,10 +45,15 @@ export class ViolationsController {
   @UsePipes(new ValidationPipe({ transform: true }))
   async index(
     @Query() query: ViolationsFilters,
+    @Request() req: ExpressRequest,
   ): Promise<Pagination<ViolationDto>> {
     const pagination = await paginate(
       this.repo.queryBuilderWithFilters(query),
-      { page: query.page, limit: 100, route: '/violations' },
+      {
+        page: query.page,
+        limit: 100,
+        route: paginationRoute(req),
+      },
     );
 
     const processViolation = async (violation: Violation) => {


### PR DESCRIPTION
## Какво променя този PR?

`links` in the pagination responses didn't work properly before as it ignored any query param filters. With this, it will omit the current page query param, keep the rest and then the pagination library would add the correct page at the end. So there will be no duplicate page params either.