### PR TITLE
Return violations assignees in admin even when filtering by assignee

### DIFF
--- a/src/violations/entities/violations.repository.ts
+++ b/src/violations/entities/violations.repository.ts
@@ -45,7 +45,7 @@ export class ViolationsRepository {
     qb.leftJoinAndSelect('violation.pictures', 'picture');
 
     if (filters.assignee) {
-      qb.innerJoin('violation.assignees', 'assignee');
+      qb.innerJoinAndSelect('violation.assignees', 'assignee');
       qb.andWhere('assignee.id = :assignee', { assignee: filters.assignee });
     } else {
       qb.leftJoinAndSelect('violation.assignees', 'assignee');


### PR DESCRIPTION
## Какво променя този PR?

Досега не връщахме assignes към сигнал в отговора от API-то когато филтрираме по assignee. Когато не филтрираме, ги имаше и преди.