### PR TITLE
Require full access to violations in order to even read violation commments

### DIFF
--- a/src/violations/api/violation-comments.controller.ts
+++ b/src/violations/api/violation-comments.controller.ts
@@ -37,7 +37,7 @@ export class ViolationCommentsController {
   @Get()
   @HttpCode(200)
   @UseGuards(PoliciesGuard)
-  @CheckPolicies((ability: Ability) => ability.can(Action.Read, Violation))
+  @CheckPolicies((ability: Ability) => ability.can(Action.Manage, Violation))
   @UsePipes(new ValidationPipe({ transform: true }))
   async index(
     @Query() query: PageDTO,


### PR DESCRIPTION
## Какво променя този PR?

Изискваме пълен достъп до сигналите в администрацията дори за да имаш достъп, за да четеш коментарите към сигнал. Иначе може и да се заобиколи контрола на достъп до сигналите.