### PR TITLE
Add POST /me/checkins for checking in a section as early as possible

### DIFF
--- a/src/checkins/api/checkin.dto.ts
+++ b/src/checkins/api/checkin.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Exclude,
+  Expose,
+  plainToClass,
+  Transform,
+  Type,
+} from 'class-transformer';
+import {
+  IsNotEmpty,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { SectionDto } from 'src/sections/api/section.dto';
+import { UserDto } from 'src/users/api/user.dto';
+import { Checkin } from '../entities/checkin.entity';
+
+@Exclude()
+export class CheckinDto {
+  @Expose({ groups: ['read'] })
+  id: string;
+
+  @ApiProperty({ required: true })
+  @Expose({ groups: ['read', 'create'] })
+  @Type(() => SectionDto)
+  @Transform(
+    ({ value: id }) => plainToClass(SectionDto, { id }, { groups: ['create'] }),
+    { groups: ['create'] },
+  )
+  @IsNotEmpty({ groups: ['create'] })
+  @ValidateNested({
+    groups: ['create'],
+  })
+  section: SectionDto;
+
+  @Expose({ groups: ['read'] })
+  timestamp: Date;
+
+  public toEntity(): Checkin {
+    return plainToClass<Checkin, Partial<CheckinDto>>(Checkin, this, {
+      groups: ['create'],
+    });
+  }
+
+  public static fromEntity(entity: Checkin): CheckinDto {
+    return plainToClass<CheckinDto, Partial<Checkin>>(CheckinDto, entity, {
+      excludeExtraneousValues: true,
+      groups: ['read'],
+    });
+  }
+}

--- a/src/checkins/checkins.module.ts
+++ b/src/checkins/checkins.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CaslModule } from 'src/casl/casl.module';
+import { User } from 'src/users/entities';
+import { UsersModule } from 'src/users/users.module';
 import { Checkin } from './entities/checkin.entity';
 import { CheckinsRepository } from './entities/checkins.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Checkin]), CaslModule],
+  imports: [TypeOrmModule.forFeature([Checkin]), CaslModule, UsersModule],
   providers: [CheckinsRepository],
   exports: [CheckinsRepository],
   controllers: [],

--- a/src/checkins/checkins.module.ts
+++ b/src/checkins/checkins.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CaslModule } from 'src/casl/casl.module';
+import { Checkin } from './entities/checkin.entity';
+import { CheckinsRepository } from './entities/checkins.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Checkin]), CaslModule],
+  providers: [CheckinsRepository],
+  exports: [CheckinsRepository],
+  controllers: [],
+})
+export class CheckinsModule {}

--- a/src/checkins/entities/checkin.entity.ts
+++ b/src/checkins/entities/checkin.entity.ts
@@ -1,0 +1,25 @@
+import { ulid } from 'ulid';
+import { Section } from 'src/sections/entities';
+import { User } from 'src/users/entities';
+import { Entity, CreateDateColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+
+@Entity('checkins', {
+  orderBy: {
+    timestamp: 'DESC',
+  },
+})
+export class Checkin {
+  @PrimaryColumn('char', {
+    length: 26,
+  })
+  id: string = ulid();
+
+  @ManyToOne(() => User, (user: User) => user.checkins)
+  actor: User;
+
+  @ManyToOne(() => Section, (section) => section.violations)
+  section?: Section;
+
+  @CreateDateColumn()
+  timestamp: Date;
+}

--- a/src/checkins/entities/checkins.repository.ts
+++ b/src/checkins/entities/checkins.repository.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Checkin } from './checkin.entity';
+
+@Injectable()
+export class CheckinsRepository {
+  constructor(@InjectRepository(Checkin) private repo: Repository<Checkin>) {}
+
+  async save(checkin: Checkin): Promise<Checkin> {
+    return await this.repo.save(checkin);
+  }
+}

--- a/src/checkins/entities/checkins.repository.ts
+++ b/src/checkins/entities/checkins.repository.ts
@@ -1,13 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { User } from 'src/users/entities';
+import { UsersRepository } from 'src/users/entities/users.repository';
 import { Repository } from 'typeorm';
 import { Checkin } from './checkin.entity';
 
 @Injectable()
 export class CheckinsRepository {
-  constructor(@InjectRepository(Checkin) private repo: Repository<Checkin>) {}
+  constructor(
+    @InjectRepository(Checkin) private checkinsRepo: Repository<Checkin>,
+    private usersRepo: UsersRepository,
+  ) {}
 
   async save(checkin: Checkin): Promise<Checkin> {
-    return await this.repo.save(checkin);
+    const savedCheckin = await this.checkinsRepo.save(checkin);
+    savedCheckin.actor.section = checkin.section;
+    await this.usersRepo.save(savedCheckin.actor);
+
+    return savedCheckin;
   }
 }

--- a/src/me/api/me-checkins.controller.ts
+++ b/src/me/api/me-checkins.controller.ts
@@ -1,0 +1,36 @@
+import {
+  Controller,
+  HttpCode,
+  Body,
+  UsePipes,
+  ValidationPipe,
+  Post,
+} from '@nestjs/common';
+import { CheckinDto } from 'src/checkins/api/checkin.dto';
+import { CheckinsRepository } from 'src/checkins/entities/checkins.repository';
+import { InjectUser } from '../../auth/decorators/inject-user.decorator';
+import { User } from '../../users/entities/user.entity';
+
+@Controller('me/checkins')
+export class MeCheckinsController {
+  constructor(private readonly checkinsRepo: CheckinsRepository) {}
+
+  @Post()
+  @HttpCode(201)
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: { groups: ['create'] },
+      groups: ['create'],
+    }),
+  )
+  async checkin(
+    @InjectUser() user: User,
+    @Body() checkinDto: CheckinDto,
+  ): Promise<CheckinDto> {
+    const client = checkinDto.toEntity();
+    client.actor = user;
+
+    return CheckinDto.fromEntity(await this.checkinsRepo.save(client));
+  }
+}

--- a/src/me/me.module.ts
+++ b/src/me/me.module.ts
@@ -15,11 +15,15 @@ import {
   MeStreamController,
   MeViolationController,
 } from './api';
+import { MeCheckinsController } from './api/me-checkins.controller';
+import { Checkin } from 'src/checkins/entities/checkin.entity';
+import { CheckinsModule } from 'src/checkins/checkins.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Client]),
+    TypeOrmModule.forFeature([User, Client, Checkin]),
     UsersModule,
+    CheckinsModule,
     CaslModule,
     ProtocolsModule,
     PicturesModule,
@@ -29,6 +33,7 @@ import {
   controllers: [
     MeProtocolsController,
     MeViolationController,
+    MeCheckinsController,
     MeClientsController,
     MeStreamController,
     MeController,

--- a/src/migrations/1625092684710-CreateTableCheckins.ts
+++ b/src/migrations/1625092684710-CreateTableCheckins.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTableCheckins1625092684710 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        create table checkins (
+          id bpchar(26) not null,
+          actor_id bpchar(26) not null,
+          section_id char(9) default null,
+          timestamp timestamp default CURRENT_TIMESTAMP,
+          primary key("id"),
+          constraint "checkins_section_id_fkey" foreign key ("section_id") references "sections" ("id"),
+          constraint "checkins_actor_id_fkey" foreign key ("actor_id") references "people" ("id")
+        );
+      `);
+
+    await queryRunner.query(`
+        create index "checkins_actor_id_timestamp_key" on "checkins" ("actor_id", "timestamp");
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        drop index "checkins_actor_id_timestamp_key";
+      `);
+    await queryRunner.query(`
+        drop table checkins;
+      `);
+  }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Checkin } from 'src/checkins/entities/checkin.entity';
 import { Protocol } from 'src/protocols/entities/protocol.entity';
 import { Section } from 'src/sections/entities';
 import { Stream } from 'src/streams/entities/stream.entity';
@@ -67,6 +68,12 @@ export class User {
     onDelete: 'CASCADE',
   })
   clients: Client[];
+
+  @OneToMany(() => Checkin, (checkin) => checkin.actor, {
+    cascade: ['remove'],
+    onDelete: 'CASCADE',
+  })
+  checkins: Checkin[];
 
   @ManyToMany(() => Protocol)
   @JoinTable({


### PR DESCRIPTION
## Какво променя този PR?

Дава възможност на потребилите на мобилното приложение - застъпници, представители и секционни членове да се отбележат в секцията в момента, в който пристигнат, за да имам видимост за разпределението по места и проблеми с логването в приложението, които да коригираме своевременно.

## Детайли

Това също би позволило по-бърз достъп до започване на видеопоток, изпращане на сигнал или на протокол от тази секция без да се минава отново през селектора на секция.

Заявка:
```
POST /me/checkins

{
  "section": "071200004"
}
```

Отговор:
```json
{
    "id": "01F9FJK6TCTZPRNA4BA707FFQE",
    "section": {
        "id": "071200004"
    },
    "timestamp": "2021-06-30T20:03:20.146Z"
}
```

Списък:

- [x] `POST /me/checkins`
- [x] Save section from latest checkin in user profile
- [x] Expose a person's section in `/me`