### PR TITLE
Order organizations by a custom sort position

### DIFF
--- a/src/migrations/1625594972743-AddOrganizationsSortPosition.ts
+++ b/src/migrations/1625594972743-AddOrganizationsSortPosition.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrganizationsSortPosition1625594972743
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `alter table organizations add column sort_position smallint default 0`,
+    );
+
+    await queryRunner.query(`
+        create index "organizations_sort_position_key" on "organizations" ("sort_position");
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        drop index "organizations_sort_position_key";
+      `);
+    await queryRunner.query(
+      `alter table organizations drop column sort_position`,
+    );
+  }
+}

--- a/src/users/entities/organization.entity.ts
+++ b/src/users/entities/organization.entity.ts
@@ -7,7 +7,7 @@ export enum OrganizationType {
   WATCHERS = 'watchers',
 }
 @Entity('organizations', {
-  orderBy: { id: 'ASC' },
+  orderBy: { sortPosition: 'ASC' },
 })
 export class Organization {
   @PrimaryGeneratedColumn()
@@ -21,4 +21,7 @@ export class Organization {
 
   @Column()
   type: OrganizationType;
+
+  @Column()
+  sortPosition: number;
 }


### PR DESCRIPTION
## Какво променя този PR?

Добавя поле за ред на организациите.

## Детайли

This help with migrating users from organizations across campaigns as
previously we were using the primary key for sorting which is also
a foreign key in the people table and is harder to modify freely.

