### PR TITLE
Extract Stream Censor as a service

### DIFF
--- a/src/migrations/1625607338385-AlterStreamIdentiferLength.ts
+++ b/src/migrations/1625607338385-AlterStreamIdentiferLength.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterStreamIdentiferLength1625607338385
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        alter table "streams" alter column "stream_identifier" TYPE varchar(20)
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        alter table "streams" alter column "stream_identifier" TYPE bpchar(20)
+      `);
+  }
+}

--- a/src/streams/api/stream-censor.service.ts
+++ b/src/streams/api/stream-censor.service.ts
@@ -1,0 +1,56 @@
+import { HttpService, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AxiosResponse } from 'axios';
+import { Observable } from 'rxjs';
+import { Stream } from '../entities/stream.entity';
+import { Role } from '../../casl/role.enum';
+import * as util from 'util';
+import { StreamsRepository } from '../entities/streams.repository';
+import { UsersRepository } from 'src/users/entities/users.repository';
+
+@Injectable()
+export class StreamCensor {
+  private readonly STOP_URL_FORMAT: string =
+    '%s//%s/stop.php?name=%s&secret=%s';
+
+  constructor(
+    private readonly streamsRepo: StreamsRepository,
+    private readonly usersRepo: UsersRepository,
+    private readonly config: ConfigService,
+    private httpService: HttpService,
+  ) {}
+
+  async censorStreamById(streamId: string) {
+    this.censorStream(await this.streamsRepo.findOneOrFail(streamId));
+  }
+
+  async censorStream(stream: Stream) {
+    if (stream.user) {
+      const index = stream.user.roles.indexOf(Role.Streamer);
+      if (index >= 0) {
+        stream.user.roles.splice(index, 1);
+        await this.usersRepo.save(stream.user);
+      }
+    }
+    stream.isCensored = true;
+
+    await this.streamsRepo.save(stream);
+    this.stopStream(stream);
+  }
+
+  private stopStream(stream: Stream): Observable<AxiosResponse<any>> {
+    const streamUrl = new URL(stream.broadcastUrl);
+    const secret = encodeURIComponent(
+      this.config.get<string>('STREAM_REJECT_SECRET'),
+    );
+    const stopUrl = util.format(
+      this.STOP_URL_FORMAT,
+      streamUrl.protocol,
+      streamUrl.hostname,
+      stream.identifier,
+      secret,
+    );
+
+    return this.httpService.post(stopUrl);
+  }
+}

--- a/src/streams/api/streams.controller.ts
+++ b/src/streams/api/streams.controller.ts
@@ -12,7 +12,6 @@ import {
   Inject,
 } from '@nestjs/common';
 import { HttpService } from '@nestjs/common';
-import { startWith } from 'rxjs/operators';
 import { InjectUser } from 'src/auth/decorators';
 import { Action } from 'src/casl/action.enum';
 import { CheckPolicies } from 'src/casl/check-policies.decorator';

--- a/src/streams/api/streams.controller.ts
+++ b/src/streams/api/streams.controller.ts
@@ -11,7 +11,6 @@ import {
   Param,
   Inject,
 } from '@nestjs/common';
-import { HttpService } from '@nestjs/common';
 import { InjectUser } from 'src/auth/decorators';
 import { Action } from 'src/casl/action.enum';
 import { CheckPolicies } from 'src/casl/check-policies.decorator';
@@ -22,8 +21,12 @@ import { UsersRepository } from 'src/users/entities/users.repository';
 import { Stream } from '../entities/stream.entity';
 import { StreamsRepository } from '../entities/streams.repository';
 import { StreamDto } from './stream.dto';
-import { Role } from '../../casl/role.enum';
 import { ConfigService } from '@nestjs/config';
+import {
+  AcceptedResponse,
+  ACCEPTED_RESPONSE_STATUS,
+} from 'src/utils/accepted-response';
+import { StreamCensor } from './stream-censor.service';
 
 @Controller('streams')
 export class StreamsController {
@@ -31,7 +34,7 @@ export class StreamsController {
     private readonly streamsRepo: StreamsRepository,
     private readonly usersRepo: UsersRepository,
     private readonly sectionsRepo: SectionsRepository,
-    private httpService: HttpService,
+    private readonly streamCensor: StreamCensor,
   ) {}
 
   @Post()
@@ -60,31 +63,14 @@ export class StreamsController {
   }
 
   @Delete(':stream')
+  @HttpCode(202)
   @UseGuards(PoliciesGuard)
   @CheckPolicies((ability: Ability) => ability.can(Action.Manage, Stream))
-  async delete(
+  delete(
     @Param('stream') streamId: string,
     @Inject(ConfigService) config: ConfigService,
-  ): Promise<StreamDto> {
-    const stream = await this.streamsRepo.findOneOrFail(streamId);
-    const index = stream.user.roles.indexOf(Role.Streamer);
-    if (index > 0) {
-      stream.user.roles.splice(index, 1);
-      await this.usersRepo.save(stream.user);
-    }
-    stream.isCensored = true;
-
-    await this.streamsRepo.save(stream);
-    const streamUrl = stream.streamUrl.substring(
-      stream.streamUrl.indexOf('/') + 2,
-    );
-    const streamServer = streamUrl.substring(0, streamUrl.indexOf('.'));
-    const secret = encodeURIComponent(
-      config.get<string>('STREAM_REJECT_SECRET'),
-    );
-    const stopUrl = `https://${streamServer}.tibroish.bg/stop.php?name=${stream.identifier}&secret=${secret}`;
-    this.httpService.post(stopUrl);
-
-    return StreamDto.fromEntity(stream);
+  ): AcceptedResponse {
+    this.streamCensor.censorStreamById(streamId);
+    return { status: ACCEPTED_RESPONSE_STATUS };
   }
 }

--- a/src/streams/entities/streams.repository.ts
+++ b/src/streams/entities/streams.repository.ts
@@ -12,14 +12,20 @@ export class StreamsRepository {
 
   findOneOrFail(id: string): Promise<Stream> {
     return this.repo.findOneOrFail({
-      where: { id },
+      where: {
+        id,
+        isCensored: false,
+      },
       relations: ['chunks', 'section', 'user'],
     });
   }
 
   findOneWithSectionOrFail(id: string): Promise<Stream> {
     return this.repo.findOneOrFail({
-      where: { id },
+      where: {
+        id,
+        isCensored: false,
+      },
       relations: [
         'chunks',
         'section',
@@ -35,6 +41,7 @@ export class StreamsRepository {
   findAvailableStreamOrFail(): Promise<Stream> {
     return this.repo.findOneOrFail({
       where: {
+        isCensored: false,
         isAssigned: false,
       },
     });
@@ -61,9 +68,7 @@ export class StreamsRepository {
     });
   }
 
-  async save(stream: Stream): Promise<Stream> {
+  async save(stream: Stream): Promise<void> {
     await this.repo.save(stream);
-
-    return this.findOneOrFail(stream.id);
   }
 }

--- a/src/streams/streams.module.ts
+++ b/src/streams/streams.module.ts
@@ -6,6 +6,8 @@ import { SectionsModule } from 'src/sections/sections.module';
 import { StreamsRepository } from './entities/streams.repository';
 import { StreamsController } from './api/streams.controller';
 import { Stream } from './entities/stream.entity';
+import { StreamCensor } from './api/stream-censor.service';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -14,8 +16,9 @@ import { Stream } from './entities/stream.entity';
     CaslModule,
     SectionsModule,
     HttpModule,
+    ConfigModule,
   ],
-  providers: [StreamsRepository],
+  providers: [StreamsRepository, StreamCensor],
   exports: [StreamsRepository],
   controllers: [StreamsController],
 })


### PR DESCRIPTION
## Какво променя този PR?

Follow-up to #73.

## Детайли

This is better in order to keep our controllers thin, have more, but simpler and named steps in the code and make the service reusable for the `Users#update` action.

## Списък:

- [x] Trim stream identifiers in database
- [x] Remove unused string library import
- [x] Simplify string URL manipulation
- [x] Do not load censored streams anywhere
- [x] Extract stream censor service out of controller
- [x] Return 202 quickly and then process the censorship