### PR TITLE
Работна опашка за валидиране

### DIFF
--- a/src/casl/role.enum.ts
+++ b/src/casl/role.enum.ts
@@ -1,6 +1,7 @@
 export enum Role {
   User = 'user',
   Validator = 'validator',
+  SuperValidator = 'super_validator',
   Lawyer = 'lawyer',
   Streamer = 'streamer',
   Admin = 'admin',

--- a/src/config/schema.config.ts
+++ b/src/config/schema.config.ts
@@ -25,4 +25,5 @@ export const configSchema = Joi.object({
     'https://tibroish.bg/results/parliament2021-07-11/',
   ),
   STREAM_REJECT_SECRET: Joi.string().required(),
+  PROTOCOLS_VALIDATION_ITERATIONS: Joi.number().default(2),
 });

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -7,8 +7,16 @@ export function setUpSwagger(app: INestApplication) {
     .setDescription(
       'Ti Broish API is built for clients sending in election results data in Bulgaria',
     )
+    .addTag(
+      'default',
+      'Supported API endpoints. See below for deprecated endpoints.',
+    )
+    .addTag(
+      'Deprecated',
+      'These endpoints are deprecated and SHOULD NOT be used for new development. They may be subject to removal.',
+    )
     .setVersion('0.1')
-    .setContact('Da Bulgaria', 'https://dabulgaria.bg', 'team@dabulgaria.bg')
+    .setContact('Ti Broish', 'https://tibroish.bg', 'team@tibroish.bg')
     .addBearerAuth(
       {
         type: 'http',

--- a/src/i18n/bg/errors.json
+++ b/src/i18n/bg/errors.json
@@ -68,5 +68,7 @@
   "VIOLATION_IS_ALREADY_UNPUBLISHED": "Сигналът вече е непубликуван",
   "VIOLATION_CANNOT_BE_PUBLISHED_WHEN_RECEIVED": "Сигналът не може да бъде публикуван когато е тепърва получен",
   "VIOLATION_CANNOT_BE_PUBLISHED_WHEN_REJECTED": "Сигналът не може да бъде публикуван когато е отхвърлен",
-  "STREAM_NOT_ASSIGNED_STREAM": "Не можете да излъчвате - трябва да сте селектирали секция и да е след края на изборния ден"
+  "STREAM_NOT_ASSIGNED_STREAM": "Не можете да излъчвате - трябва да сте селектирали секция и да е след края на изборния ден",
+  "ERROR_CANNOT_ADD_PROTOCOL_TO_VALIDATION_QUEUE_IF_NOT_SETTLED": "Не може да се добави протокол в опашката за валидиране, ако не е със статус получен.",
+  "ERROR_CANNOT_ADD_PROTOCOL_TO_ARBITRATION_QUEUE_IF_NOT_SETTLED": "Не може да се добави протокол в опашката за арбитраж, ако не е вече обработен."
 }

--- a/src/i18n/en/errors.json
+++ b/src/i18n/en/errors.json
@@ -68,5 +68,7 @@
   "VIOLATION_IS_ALREADY_UNPUBLISHED": "Violation is already unpublished",
   "VIOLATION_CANNOT_BE_PUBLISHED_WHEN_RECEIVED": "Violation cannot be published when it is just received",
   "VIOLATION_CANNOT_BE_PUBLISHED_WHEN_REJECTED": "Violation cannot be published when it is rejected",
-  "STREAM_NOT_ASSIGNED_STREAM": "You cannot stream yet - you should either select a section first or wait for the end of election day"
+  "STREAM_NOT_ASSIGNED_STREAM": "You cannot stream yet - you should either select a section first or wait for the end of election day",
+  "ERROR_CANNOT_ADD_PROTOCOL_TO_VALIDATION_QUEUE_IF_NOT_RECEIVED": "Cannot add a protocol for validation if it is not received.",
+  "ERROR_CANNOT_ADD_PROTOCOL_TO_ARBITRATION_QUEUE_IF_NOT_SETTLED": "Cannot add a protocol for arbitration if it is not processed yet."
 }

--- a/src/migrations/1625609333009-AddWorkItems.ts
+++ b/src/migrations/1625609333009-AddWorkItems.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWorkItems1625609333009 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        create table "work_items" (
+          "id" bpchar(26) not null,
+          "type" varchar not null,
+          "origin" varchar not null,
+          "protocol_id" bpchar(26) not null,
+          "assignee_id" bpchar(26) default null,
+          "is_assigned" boolean default false,
+          "is_complete" boolean default false,
+          "queue_position" bit(7) NOT NULL,
+          "created_at" timestamp default CURRENT_TIMESTAMP,
+          "completed_at" timestamp default NULL,
+          primary key("id"),
+          constraint "work_items_protocol_id_fkey" foreign key ("protocol_id") references "protocols" ("id"),
+          constraint "work_items_assignee_id_fkey" foreign key ("assignee_id") references "people" ("id")
+        );
+      `);
+    await queryRunner.query(`
+        create index "work_items_type_key" on "work_items" ("type");
+        create index "work_items_protocol_id_key" on "work_items" ("protocol_id");
+        create index "work_items_type_is_assigned_is_complete_key" on "work_items" ("protocol_id");
+        create index "work_items_queue_position_id_key" on "work_items" ("queue_position", "id");
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        drop index "work_items_type_key";
+        drop index "work_items_protocol_id_key";
+        drop index "work_items_type_is_assigned_is_complete_key";
+        drop index "work_items_queue_position_id_key";
+      `);
+
+    await queryRunner.query(`
+        drop table "work_items";
+      `);
+  }
+}

--- a/src/migrations/1625635791732-MakeWorkItemsProtocolAssigneeUnique.ts
+++ b/src/migrations/1625635791732-MakeWorkItemsProtocolAssigneeUnique.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MakeWorkItemsProtocolAssigneeUnique1625635791732
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        alter table "work_items" add constraint "work_items_protocol_id_assignee_id_uniq" UNIQUE("protocol_id", "assignee_id");
+      `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        alter table "work_items" drop constraint "work_items_protocol_id_assignee_id_uniq";
+      `);
+  }
+}

--- a/src/protocols/api/protocol-assignees.controller.ts
+++ b/src/protocols/api/protocol-assignees.controller.ts
@@ -15,6 +15,7 @@ import {
   Delete,
   NotFoundException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { Action } from '../../casl/action.enum';
 import { CheckPolicies } from '../../casl/check-policies.decorator';
@@ -29,6 +30,8 @@ import { InjectUser } from '../../auth/decorators/inject-user.decorator';
 import { User } from '../../users/entities';
 import { Protocol } from '../entities/protocol.entity';
 import { ProtocolsRepository } from '../entities/protocols.repository';
+import { CaslAbilityFactory } from 'src/casl/casl-ability.factory';
+import { ApiTags } from '@nestjs/swagger';
 
 @Controller('protocols')
 export class ProtocolAssigneesController {
@@ -36,12 +39,13 @@ export class ProtocolAssigneesController {
     @Inject(ProtocolsRepository)
     private readonly protocolsRepo: ProtocolsRepository,
     @Inject(UsersRepository) private readonly usersRepo: UsersRepository,
+    private caslAbilityFactory: CaslAbilityFactory,
   ) {}
 
   @Get(':protocol/assignees')
   @HttpCode(200)
   @UseGuards(PoliciesGuard)
-  @CheckPolicies((ability: Ability) => ability.can(Action.Update, Protocol))
+  @CheckPolicies((ability: Ability) => ability.can(Action.Manage, Protocol))
   async getAssignees(
     @Param('protocol') protocolId: string,
   ): Promise<UserDto[]> {
@@ -108,6 +112,7 @@ export class ProtocolAssigneesController {
     @Body() assigneeDto: UserDto,
     @InjectUser() actor: User,
   ): Promise<AcceptedResponse> {
+    this.checkIfCanEditAssignees(actor, assigneeDto.id);
     const protocol = await this.protocolsRepo.findOneOrFail(protocolId);
     if (protocol.assignees.length > 0) {
       throw new BadRequestException(
@@ -134,8 +139,10 @@ export class ProtocolAssigneesController {
   async deleteAssignee(
     @Param('protocol') protocolId: string,
     @Param('assignee') assigneeId: string,
-    @InjectUser() user: User,
+    @InjectUser() actor: User,
   ): Promise<AcceptedResponse> {
+    this.checkIfCanEditAssignees(actor, assigneeId);
+
     const protocol = await this.protocolsRepo.findOneOrFail(protocolId);
     const assigneeToBeDeleted = await this.usersRepo.findOneOrFail(assigneeId);
     const assignees = protocol.assignees;
@@ -146,9 +153,24 @@ export class ProtocolAssigneesController {
       throw new NotFoundException('ASSIGNEE_NOT_FOUND');
     }
     assignees.splice(foundIndex, 1);
-    protocol.assign(user, assignees);
+    protocol.assign(actor, assignees);
     await this.protocolsRepo.save(protocol);
 
     return { status: ACCEPTED_RESPONSE_STATUS };
+  }
+
+  private checkIfCanEditAssignees(actor: User, assigneeId: string): boolean {
+    // If the assignee is the actor, allow to edit
+    // If not, check if actor can manage the protocol
+    if (actor.id === assigneeId) {
+      return true;
+    }
+
+    const ability = this.caslAbilityFactory.createForUser(actor);
+    if (ability.can(Action.Manage, Protocol)) {
+      return true;
+    }
+
+    throw new ForbiddenException('Cannot change assignments for others users!');
   }
 }

--- a/src/protocols/api/protocol-assignees.controller.ts
+++ b/src/protocols/api/protocol-assignees.controller.ts
@@ -50,7 +50,11 @@ export class ProtocolAssigneesController {
     return protocol.assignees.map((user: User) => UserDto.fromEntity(user));
   }
 
+  /**
+   * @deprecated No need to manage multiple assignees at once
+   */
   @Put(':protocol/assignees')
+  @ApiTags('Deprecated')
   @HttpCode(200)
   @UseGuards(PoliciesGuard)
   @CheckPolicies((ability: Ability) => ability.can(Action.Update, Protocol))

--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -118,7 +118,7 @@ export class ProtocolsController {
     protocol.setReceivedStatus(user);
 
     const savedProtocol = await this.repo.save(protocol);
-    this.workQueue.addProtocol(protocol);
+    this.workQueue.addProtocolForValidation(protocol);
     const savedDto = ProtocolDto.fromEntity(savedProtocol, [
       UserDto.AUTHOR_READ,
     ]);

--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -173,8 +173,7 @@ export class ProtocolsController {
   ): Promise<AcceptedResponse> {
     const protocol = await this.repo.findOneOrFail(id);
     protocol.reject(user);
-
-    await this.repo.save(protocol);
+    this.workQueue.completeItem(user, protocol);
 
     return { status: ACCEPTED_RESPONSE_STATUS };
   }
@@ -189,8 +188,7 @@ export class ProtocolsController {
   ): Promise<AcceptedResponse> {
     const protocol = await this.repo.findOneOrFail(id);
     protocol.approve(user);
-
-    await this.repo.save(protocol);
+    this.workQueue.completeItem(user, protocol);
 
     return { status: ACCEPTED_RESPONSE_STATUS };
   }
@@ -215,10 +213,9 @@ export class ProtocolsController {
   ): Promise<ProtocolResultsDto> {
     const protocol = await this.repo.findOneOrFail(protocolId);
     protocol.populate(user, resultsDto.toResults());
+    await this.workQueue.completeItem(user, protocol);
 
-    const savedProtocol = await this.repo.save(protocol);
-
-    return ProtocolResultsDto.fromEntity(savedProtocol);
+    return ProtocolResultsDto.fromEntity(protocol);
   }
 
   @Post(':id/replace')

--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -48,6 +48,7 @@ import { BadRequestException } from '@nestjs/common';
 import { paginationRoute } from 'src/utils/pagination-route';
 import { WorkQueue } from './work-queue.service';
 import { WorkItem } from '../entities/work-item.entity';
+import { ApiTags } from '@nestjs/swagger';
 
 @Controller('protocols')
 export class ProtocolsController {
@@ -178,8 +179,12 @@ export class ProtocolsController {
     return { status: ACCEPTED_RESPONSE_STATUS };
   }
 
+  /**
+   * @deprecated Not really useful anymore to approve a protocol as-is
+   */
   @Post(':id/approve')
   @HttpCode(202)
+  @ApiTags('Deprecated')
   @UseGuards(PoliciesGuard)
   @CheckPolicies((ability: Ability) => ability.can(Action.Update, Protocol))
   async approve(

--- a/src/protocols/api/work-queue.service.ts
+++ b/src/protocols/api/work-queue.service.ts
@@ -12,7 +12,7 @@ export class WorkQueue {
     @Inject(ConfigService) private readonly config: ConfigService,
   ) {}
 
-  async addProtocol(protocol: Protocol): Promise<WorkItem[]> {
+  async addProtocolForValidation(protocol: Protocol): Promise<WorkItem[]> {
     const iterations = this.config.get<number>(PROTOCOLS_VALIDATION_ITERATIONS);
     const workItems: WorkItem[] = [];
 

--- a/src/protocols/api/work-queue.service.ts
+++ b/src/protocols/api/work-queue.service.ts
@@ -1,0 +1,27 @@
+import { Inject } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Protocol } from '../entities/protocol.entity';
+import { WorkItem } from '../entities/work-item.entity';
+import { WorkItemsRepository } from '../entities/work-items.repository';
+
+const PROTOCOLS_VALIDATION_ITERATIONS = 'PROTOCOLS_VALIDATION_ITERATIONS';
+
+export class WorkQueue {
+  constructor(
+    private readonly worksItemsRepo: WorkItemsRepository,
+    @Inject(ConfigService) private readonly config: ConfigService,
+  ) {}
+
+  async addProtocol(protocol: Protocol): Promise<WorkItem[]> {
+    const iterations = this.config.get<number>(PROTOCOLS_VALIDATION_ITERATIONS);
+    const workItems: WorkItem[] = [];
+
+    [...Array(iterations).keys()].forEach(() =>
+      workItems.push(WorkItem.createProtocolValidationWorkItem(protocol)),
+    );
+
+    await this.worksItemsRepo.save(workItems);
+
+    return workItems;
+  }
+}

--- a/src/protocols/api/work-queue.service.ts
+++ b/src/protocols/api/work-queue.service.ts
@@ -69,11 +69,24 @@ export class WorkQueue {
       protocol,
       assigneeToBeDeleted,
     );
-    if (workItem) {
-      workItem.protocol = protocol;
-      workItem.unassign(actor);
-      this.worksItemsRepo.save(workItem);
+    if (!workItem) {
+      return;
     }
+
+    workItem.protocol = protocol;
+    workItem.unassign(actor);
+    this.worksItemsRepo.save(workItem);
+  }
+
+  async completeItem(actor: User, protocol: Protocol): Promise<void> {
+    const workItem = await this.worksItemsRepo.findOne(protocol, actor);
+    if (!workItem) {
+      throw new Error('Work item not found!');
+    }
+
+    workItem.protocol = protocol;
+    workItem.complete();
+    this.worksItemsRepo.save(workItem);
   }
 
   private async getAvailableWorkItemForValidation(

--- a/src/protocols/api/work-queue.service.ts
+++ b/src/protocols/api/work-queue.service.ts
@@ -60,6 +60,22 @@ export class WorkQueue {
     return this.getAvailableWorkItemForValidation(user);
   }
 
+  async unassignFromProtocol(
+    actor: User,
+    protocol: Protocol,
+    assigneeToBeDeleted: User,
+  ): Promise<void> {
+    const workItem = await this.worksItemsRepo.findOne(
+      protocol,
+      assigneeToBeDeleted,
+    );
+    if (workItem) {
+      workItem.protocol = protocol;
+      workItem.unassign(actor);
+      this.worksItemsRepo.save(workItem);
+    }
+  }
+
   private async getAvailableWorkItemForValidation(
     user: User,
   ): Promise<WorkItem> {

--- a/src/protocols/entities/protocol.entity.ts
+++ b/src/protocols/entities/protocol.entity.ts
@@ -118,6 +118,14 @@ export class Protocol {
     ).actor;
   }
 
+  isReceived(): boolean {
+    return this.status === ProtocolStatus.RECEIVED;
+  }
+
+  isSettled(): boolean {
+    return this.status !== ProtocolStatus.RECEIVED;
+  }
+
   setReceivedStatus(sender: User): void {
     if (this.status) {
       throw new ProtocolStatusException(this, ProtocolStatus.RECEIVED);
@@ -140,7 +148,7 @@ export class Protocol {
   }
 
   reject(actor: User): void {
-    if (this.status !== ProtocolStatus.RECEIVED) {
+    if (!this.isReceived()) {
       throw new ProtocolStatusException(this, ProtocolStatus.REJECTED);
     }
 
@@ -149,7 +157,7 @@ export class Protocol {
   }
 
   approve(actor: User): void {
-    if (this.status !== ProtocolStatus.RECEIVED) {
+    if (!this.isReceived()) {
       throw new ProtocolStatusException(this, ProtocolStatus.APPROVED);
     }
 

--- a/src/protocols/entities/protocol.entity.ts
+++ b/src/protocols/entities/protocol.entity.ts
@@ -20,6 +20,7 @@ import {
   ProtocolStatusException,
   ProtocolHasResultsException,
 } from './protocol.exceptions';
+import { WorkItem } from './work-item.entity';
 
 export enum ProtocolStatus {
   RECEIVED = 'received',
@@ -91,6 +92,12 @@ export class Protocol {
     },
   )
   results: ProtocolResult[];
+
+  @OneToMany(
+    () => WorkItem,
+    (workItem: WorkItem): Protocol => workItem.protocol,
+  )
+  workItems: WorkItem[];
 
   @ManyToOne(() => Protocol, {
     cascade: ['insert', 'update'],

--- a/src/protocols/entities/work-item.entity.ts
+++ b/src/protocols/entities/work-item.entity.ts
@@ -54,6 +54,7 @@ export class WorkItem {
   @ManyToOne(
     () => Protocol,
     (protocol: Protocol): WorkItem[] => protocol.workItems,
+    { cascade: ['insert', 'update'] },
   )
   @JoinColumn({
     name: 'protocol_id',
@@ -114,6 +115,13 @@ export class WorkItem {
     workItem.setPosition(queuePosition);
 
     return workItem;
+  }
+
+  assign(assignee: User): void {
+    this.isAssigned = true;
+    this.assignee = assignee;
+    // Kept for auditing and backwards compatibility
+    this.protocol.assign(assignee, [assignee]);
   }
 
   private setPosition(position: number): void {

--- a/src/protocols/entities/work-item.entity.ts
+++ b/src/protocols/entities/work-item.entity.ts
@@ -143,6 +143,11 @@ export class WorkItem {
     }
   }
 
+  complete(): void {
+    this.isComplete = true;
+    this.completedAt = new Date();
+  }
+
   private setPosition(position: number): void {
     this.queuePosition = position.toString(2);
   }

--- a/src/protocols/entities/work-item.entity.ts
+++ b/src/protocols/entities/work-item.entity.ts
@@ -1,0 +1,95 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import { ulid } from 'ulid';
+import { Protocol } from './protocol.entity';
+import { User } from '../../users/entities';
+
+export enum WorkItemType {
+  PROTOCOL_VALIDATION = 'protocol_validation',
+  PROTOCOL_VALIDATION_DIFF_ARBITRAGE = 'protocol_validation_diff_arbitrage',
+}
+
+export enum WorkItemOrigin {
+  PROTOCOL_RECEIVED = 'protocol_received',
+  PROTOCOL_VALIDATION_DIFF = 'protocol_validation_diff',
+}
+
+// Last rank in the queue by having the highest position
+const DEFAULT_POSITION = 0b1111111;
+
+export const QUEUE_POSITION_TIERS = {
+  HAS_NO_OTHER_VALIDATION_COMPLETED: 0b1000000,
+  HAS_PROTOCOL_FROM_SAME_ELECTION_REGION: 0b0100000,
+  HAS_PROTOCOL_FROM_SAME_COUNTRY_MUNICIPALITY: 0b0110000,
+  HAS_PROTOCOL_FROM_SAME_CITY_REGION: 0b0111000,
+  HAS_PROTOCOL_FROM_SAME_SECTION: 0b0111100,
+  PROTOCOL_IS_FROM_A_MUNICIPALITY_TOWN: 0b0000010,
+  PROTOCOL_IS_NOT_FROM_DB_ORG: 0b0000001,
+};
+
+@Entity('work_items', {
+  orderBy: {
+    queuePosition: 'ASC',
+    id: 'ASC',
+  },
+})
+export class WorkItem {
+  @PrimaryColumn('char', {
+    length: 26,
+  })
+  id: string = ulid();
+
+  @Column({ type: 'varchar' })
+  type: WorkItemType;
+
+  @Column({ type: 'varchar' })
+  origin: WorkItemOrigin;
+
+  @ManyToOne(
+    () => Protocol,
+    (protocol: Protocol): WorkItem[] => protocol.workItems,
+  )
+  @JoinColumn({
+    name: 'protocol_id',
+  })
+  protocol: Protocol;
+
+  @ManyToOne(() => User, (user: User): WorkItem[] => user.assignedWorkItems)
+  assignee: User;
+
+  @Column()
+  isAssigned: boolean;
+
+  @Column()
+  isComplete: boolean;
+
+  @Column('bit')
+  queuePosition: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column('timestamp')
+  completedAt: Date;
+
+  public static create(
+    type: WorkItemType,
+    origin: WorkItemOrigin,
+    protocol: Protocol,
+    queuePosition: number = DEFAULT_POSITION,
+  ): WorkItem {
+    const workItem = new WorkItem();
+    workItem.type = type;
+    workItem.origin = origin;
+    workItem.protocol = protocol;
+    workItem.queuePosition = queuePosition;
+
+    return workItem;
+  }
+}

--- a/src/protocols/entities/work-item.entity.ts
+++ b/src/protocols/entities/work-item.entity.ts
@@ -130,6 +130,10 @@ export class WorkItem {
       throw new Error('Cannot unassign a work item without an assignee.');
     }
 
+    if (this.isComplete) {
+      throw new Error('Cannot unassign from a completed work item.');
+    }
+
     const assigneeToBeRemoved = this.assignee;
     this.isAssigned = false;
     this.assignee = null;
@@ -144,6 +148,10 @@ export class WorkItem {
   }
 
   complete(): void {
+    if (this.isComplete) {
+      throw new Error('Cannot complete an already  completed work item.');
+    }
+
     this.isComplete = true;
     this.completedAt = new Date();
   }

--- a/src/protocols/entities/work-items.repository.ts
+++ b/src/protocols/entities/work-items.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '../../users/entities';
+import {
+  Repository,
+  SelectQueryBuilder,
+  getConnection,
+  In,
+  Brackets,
+} from 'typeorm';
+import { ProtocolActionType } from './protocol-action.entity';
+import { shuffle } from 'lodash';
+import { WorkItem } from './work-item.entity';
+import { Protocol } from './protocol.entity';
+
+@Injectable()
+export class WorkItemsRepository {
+  constructor(
+    @InjectRepository(WorkItem) private readonly repo: Repository<WorkItem>,
+  ) {}
+
+  getRepo(): Repository<WorkItem> {
+    return this.repo;
+  }
+
+  findOne(protocol: Protocol, assignee: User): Promise<WorkItem | null> {
+    return this.repo.findOne({
+      join: {
+        alias: 'workItem',
+        innerJoin: {
+          protocol: 'workItem.protocol',
+          assignee: 'workItem.assignee',
+        },
+      },
+      where: (qb: SelectQueryBuilder<WorkItem>) => {
+        qb.andWhere('protocol.id = :protocolId', {
+          protocolId: protocol.id,
+        }).andWhere('assignee.id = :assignee', {
+          assignee: assignee.id,
+        });
+      },
+      relations: ['protocol'],
+    });
+  }
+
+  async save(workItem: WorkItem): Promise<WorkItem>;
+  async save(workItems: WorkItem[]): Promise<WorkItem[]>;
+
+  async save(input: WorkItem | WorkItem[]): Promise<WorkItem | WorkItem[]> {
+    const workItems = Array.isArray(input) ? input : [input];
+    await this.repo.save(workItems);
+
+    return workItems;
+  }
+}

--- a/src/protocols/entities/work-items.repository.ts
+++ b/src/protocols/entities/work-items.repository.ts
@@ -44,10 +44,6 @@ export class WorkItemsRepository {
     });
   }
 
-  private findOneOrFail(id: string): Promise<WorkItem> {
-    return this.repo.findOneOrFail(id, { relations: ['protocol'] });
-  }
-
   async save(workItem: WorkItem): Promise<WorkItem>;
   async save(workItems: WorkItem[]): Promise<WorkItem[]>;
 

--- a/src/protocols/entities/work-items.repository.ts
+++ b/src/protocols/entities/work-items.repository.ts
@@ -40,7 +40,7 @@ export class WorkItemsRepository {
           assignee: assignee.id,
         });
       },
-      relations: ['protocol'],
+      relations: ['protocol', 'assignee'],
     });
   }
 

--- a/src/protocols/protocols.module.ts
+++ b/src/protocols/protocols.module.ts
@@ -12,15 +12,20 @@ import { ViolationsModule } from '../violations/violations.module';
 import { SectionsModule } from 'src/sections/sections.module';
 import { ProtocolsStatusesController } from './api/protocols-statuses.controller';
 import { ProtocolsOriginsController } from './api/protocols-origins.controller';
+import { WorkQueue } from './api/work-queue.service';
+import { ConfigModule } from '@nestjs/config';
+import { WorkItemsRepository } from './entities/work-items.repository';
+import { WorkItem } from './entities/work-item.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Protocol, Violation]),
+    TypeOrmModule.forFeature([Protocol, Violation, WorkItem]),
     CaslModule,
     PicturesModule,
     UsersModule,
     SectionsModule,
     ViolationsModule,
+    ConfigModule,
   ],
   controllers: [
     ProtocolsStatusesController,

--- a/src/protocols/protocols.module.ts
+++ b/src/protocols/protocols.module.ts
@@ -33,7 +33,7 @@ import { WorkItem } from './entities/work-item.entity';
     ProtocolsController,
     ProtocolAssigneesController,
   ],
-  providers: [ProtocolsRepository],
+  providers: [ProtocolsRepository, WorkQueue, WorkItemsRepository],
   exports: [ProtocolsRepository],
 })
 export class ProtocolsModule {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,5 +1,6 @@
 import { Checkin } from 'src/checkins/entities/checkin.entity';
 import { Protocol } from 'src/protocols/entities/protocol.entity';
+import { WorkItem } from 'src/protocols/entities/work-item.entity';
 import { Section } from 'src/sections/entities';
 import { Stream } from 'src/streams/entities/stream.entity';
 import { Violation } from 'src/violations/entities/violation.entity';
@@ -90,6 +91,9 @@ export class User {
     inverseJoinColumn: { name: 'violation_id' },
   })
   assignedViolations: Violation[];
+
+  @OneToMany(() => WorkItem, (workItem: WorkItem): User => workItem.assignee)
+  assignedWorkItems: WorkItem[];
 
   @OneToOne(() => Stream, {
     cascade: ['update'],


### PR DESCRIPTION
## Какво променя този PR?

Подменя имплементацията на опашката за валидиране на протоколи

## Детайли

Вече вместо динамична опашка имаме статична опашка от протоколи в базата с данни.
Контролира се при записване на протокол вместо при четене.

Когато се получи протокол се въвеждат N на брой "work items", които се приоритизират на база на bitmask от условия.

Цели:

- Да постигнем двойна (или повече) валидация на един и същ протокол от няколко валидатора паралелно. Съответно ни е нужна по-голяма гъвкавост колко хора валидират един протокол без да се повтарят.
- Да постигнем по-полезно приоритизиране на протоколите в опашката без да правим много сложни при взимане от опашката.
- Да запазим auditability на действията - кой кога е взимал, връщал и валидирал протокол.
- Всички досегашни endpoints за валидиране да продължат да работят от гледна точка на клиента по същия начин - а именно:
  - `POST /protocols/assign`
  - `DELETE /protocols/:protocol/assignees/:assignee`
  - `POST /protocols/:protocol/results`
  - `GET /protocols?assignee=:assignee`

## Списък:

- [x] Добавяне на протоколи в опашката за валидиране
- [x] Взимане на протоколи от опашката:
	- [x] Взимане на вече възложен, но невалидиран протокол (както досега)
	- [x] Намиране на свободен протокол от опашката по приоритет, който не е валидиран от теб
- [x] Откачане от протокол (връщане свободен в опашката
- [x] Завършване на валидацията на протокол (приемане)
- [x] Отхвърляне на протокол

Следващи pull requests:
- Пресмятане на приоритет при вкарване на протокол в опашката на база на досегашни валидации с цел нормално разпределение
- Сравняване на данните при двойна валидация и при разлика добавяне на "work item" в опашката за арбитраж.

## Бележки за deployment

Всичко би трябвало да е backwards-compatible.
Не се предвижда миграция за попълване на досегашни отворени протоколи за валидиране, защото няма практичната нужда.