### PR TITLE
Correct crumbs in section results

### DIFF
--- a/src/results/api/crumb-maker.service.ts
+++ b/src/results/api/crumb-maker.service.ts
@@ -1,22 +1,27 @@
 import { Inject } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Section } from 'src/sections/entities';
+import { Municipality, Section } from 'src/sections/entities';
 import { mapToType, NodeType } from './results.controller';
 
 export class CrumbMaker {
   constructor(@Inject(ConfigService) private readonly config: ConfigService) {}
 
   makeCrumbs(items: any[]) {
+    const segments = [];
     return items
       .filter((x) => !!x)
       .reduce(
         (crumbs: Record<string, string>[], item) => {
+          segments.push(item.code);
+          if (item instanceof Municipality && item.isMunicipalityHidden()) {
+            return crumbs;
+          }
+
           crumbs.push({
             segment:
               item instanceof Section
                 ? item.id
-                : crumbs.reduce((acc, x) => `${acc}${x.segment}`, '') +
-                  item.code,
+                : segments.reduce((acc, x) => `${acc}${x}`, ''),
             name: item.name,
             type: mapToType(item),
           });

--- a/src/sections/entities/municipality.entity.ts
+++ b/src/sections/entities/municipality.entity.ts
@@ -28,4 +28,11 @@ export class Municipality {
 
   @ApiProperty({ type: () => CityRegion })
   cityRegions: Record<string, CityRegion> = {};
+
+  public isMunicipalityHidden(): boolean {
+    return (
+      (this.towns.length === 1 && this.towns[0].cityRegions.length > 0) ||
+      this.electionRegions.length > 1
+    );
+  }
 }


### PR DESCRIPTION
- [x] Do not show hidden municipalities as a crumb.
- [x] Do not duplicate election region number in crumbs.

Fixes #89.