### PR TITLE
Протоколи без секция

### DIFF
--- a/src/migrations/1676413609314-MakeProtocolsSectionOptional.ts
+++ b/src/migrations/1676413609314-MakeProtocolsSectionOptional.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class MakeProtocolsSectionOptional1676413609314
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "protocols" ALTER COLUMN "section_id" DROP NOT NULL;
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "protocols" ALTER COLUMN "section_id" SET NOT NULL;
+    `)
+  }
+}

--- a/src/protocols/api/protocol.dto.ts
+++ b/src/protocols/api/protocol.dto.ts
@@ -53,12 +53,15 @@ export class ProtocolDto {
     ],
   })
   @Type(() => SectionDto)
-  @IsOptional({ groups: ['replace'] })
+  @IsOptional({ groups: ['create'] })
   @Transform(
-    ({ value: id }) => plainToClass(SectionDto, { id }, { groups: ['create'] }),
-    { groups: ['create'] },
+    ({ value: id }): any =>
+      id
+        ? plainToClass(SectionDto, { id }, { groups: ['create', 'replace'] })
+        : id,
+    { groups: ['create', 'replace'] },
   )
-  @IsNotEmpty({ groups: ['create'] })
+  @IsNotEmpty({ groups: ['replace'] })
   @ValidateNested({
     groups: ['create', 'replace'],
   })

--- a/src/protocols/api/protocol.dto.ts
+++ b/src/protocols/api/protocol.dto.ts
@@ -301,6 +301,11 @@ export class ProtocolDto {
   })
   machineVotesCount?: number
 
+  @Expose({
+    groups: ['protocol.validate'],
+  })
+  origin: string
+
   private author: UserDto
 
   @Expose({ groups: ['protocol.validate'] })

--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -107,11 +107,11 @@ export class ProtocolsController {
     @Body() protocolDto: ProtocolDto,
     @InjectUser() user?: User,
   ): Promise<ProtocolDto> {
-    const protocol = protocolDto.toEntity()
+    const protocol = protocolDto.toEntity(['create'])
     protocol.receive(user)
 
     const savedProtocol = await this.repo.save(protocol)
-    this.workQueue.addProtocolForValidation(protocol)
+    void this.workQueue.addProtocolForValidation(protocol)
     const savedDto = ProtocolDto.fromEntity(savedProtocol, [
       'read',
       'author_read',

--- a/src/protocols/entities/protocol.entity.ts
+++ b/src/protocols/entities/protocol.entity.ts
@@ -80,7 +80,7 @@ export class Protocol {
   metadata: ProtocolData
 
   @ManyToOne(() => Section, (section) => section.protocols, { eager: true })
-  section: Section
+  section?: Section
 
   @ManyToMany(() => Picture, {
     cascade: ['insert', 'update'],

--- a/src/protocols/entities/protocols.repository.ts
+++ b/src/protocols/entities/protocols.repository.ts
@@ -85,8 +85,8 @@ export class ProtocolsRepository {
 
     const qb = this.repo.createQueryBuilder('protocol')
 
-    qb.innerJoinAndSelect('protocol.section', 'section')
-    qb.innerJoinAndSelect('section.town', 'town')
+    qb.leftJoinAndSelect('protocol.section', 'section')
+    qb.leftJoinAndSelect('section.town', 'town')
     qb.innerJoinAndSelect('protocol.pictures', 'picture')
     qb.innerJoinAndSelect(
       'protocol.actions',


### PR DESCRIPTION
## Какво променя този PR?

Closes #103 

## Детайли

Позволява изпращане на протоколи без посочване на секция и преглеждането им в преброителния център.

В същото време запазва backwards compatibility с мобилните приложения, които могат да продължат да изпращат секцията.

## Списък:

- [x] Позволява приемане на протокол без секция, само със снимки
- [x] Позволява приемането на протокол и със секция
- [x] Валидира секцията само когато е подадена
- [x] Списъкът на протоколи в админа показва протоколи и без секция