### PR TITLE
Връщане на локация при липсваща секция

### DIFF
--- a/src/sections/api/section.dto.ts
+++ b/src/sections/api/section.dto.ts
@@ -6,10 +6,11 @@ import { ViolationDto } from 'src/violations/api/violation.dto'
 import { Section } from '../entities/section.entity'
 import { CityRegionDto } from './cityRegion.dto'
 import { ElectionRegionDto } from './electionRegion.dto'
+import { MunicipalityDto } from './municipality.dto'
 import { IsSectionExists } from './section-exists.constraint'
 import { TownDto } from './town.dto'
 
-const allowedGroups = ['read', 'get']
+const allowedGroups = ['read', 'get', 'partialMatch']
 
 @Exclude()
 export class SectionDto {
@@ -116,6 +117,7 @@ export class SectionDto {
     groups: [
       'get',
       'read',
+      'partialMatch',
       StreamDto.READ,
       ViolationDto.FEED,
       StreamDto.FEED,
@@ -129,6 +131,7 @@ export class SectionDto {
     groups: [
       'get',
       'read',
+      'partialMatch',
       StreamDto.READ,
       StreamDto.FEED,
       'protocol.protocolInResults',
@@ -141,6 +144,7 @@ export class SectionDto {
     groups: [
       'get',
       'read',
+      'partialMatch',
       StreamDto.READ,
       ViolationDto.FEED,
       'protocol.protocolInResults',

--- a/src/sections/api/town.dto.ts
+++ b/src/sections/api/town.dto.ts
@@ -50,6 +50,7 @@ export class TownDto {
     groups: [
       'get',
       'read',
+      'partialMatch',
       StreamDto.READ,
       'violations.feed',
       'stream.feed',
@@ -64,6 +65,7 @@ export class TownDto {
     groups: [
       'get',
       'read',
+      'partialMatch',
       StreamDto.READ,
       'violations.feed',
       'stream.feed',

--- a/src/sections/entities/country.entity.ts
+++ b/src/sections/entities/country.entity.ts
@@ -1,6 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger'
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm'
-import { CityRegion } from '.'
 import { Town } from './town.entity'
 import { WithCode } from './withCode.interface'
 
@@ -22,7 +20,4 @@ export class Country implements WithCode {
   public readonly towns: Town[]
 
   sectionsCount: number
-
-  @ApiProperty({ type: () => CityRegion })
-  cityRegions: Record<string, CityRegion> = {}
 }


### PR DESCRIPTION
Това е нужно за ti-broish/admin#68

Closes #186 

Преизползвам направеното в #189, за да връщам данните за локацията на една секция когато тя липсва.

API-то ще връща 404 когато секцията липсва, но ако има секция със същите първи 6 знака ще връща данните за държавата, МИР-а и общината. Данните за града няма как да са със сигурност същите, но структурата ще се запази и общината ще се показва през полето за град, дори да няма данни за град.

<table>
<thead>
<tr>
<th>section</th>
<th>response status code</th>
<th>response body</th>
<th>notes</th>
</tr>
</thead>
<tbody>
<tr>
<td>

`010100002`
</td>
<td>

`200`
</td>
<td>

```json
{
  "code": "002",
  "electionRegion": {
    "code": "01",
    "isAbroad": false,
    "name": "Благоевград"
  },
  "id": "010100002",
  "isMachine": null,
  "isMobile": false,
  "place": "ПЛТГ \"Н. Вапцаров\"",
  "population": 0,
  "riskLevel": null,
  "town": {
    "country": {
      "code": "00",
      "isAbroad": false,
      "name": "България"
    },
    "id": 2676,
    "municipality": {
      "code": "01",
      "name": "Банско"
    },
    "name": "гр. Банско"
  },
  "votersCount": 544
}
```
</td>
<td>Секция, която съществува</td>
</tr>
<tr>
<td>

`010100099`
</td>
<td>

`404`
</td>
<td>

```json
{
  "electionRegion": {
    "code": "01",
    "isAbroad": false,
    "name": "Благоевград"
  },
  "town": {
    "country": {
      "code": "00",
      "isAbroad": false,
      "name": "България"
    },
    "id": 2676,
    "municipality": {
      "code": "01",
      "name": "Банско"
    }
  }
}
```
</td>
<td>Секция, която не съществува</td>
</tr>
<tr>
<td>

`019900001`
</td>
<td>

`404`
</td>
<td>

```json
{
    "message": "Resource not found.",
    "statusCode": 404
}
```
</td>
<td>Секция, която не съществува и няма въобще секция в тази община/държава</td>
</tr>
</tbody>
</table>
