### PR TITLE
Remove unused protocol_data table

### DIFF
--- a/scripts/import-results.ts
+++ b/scripts/import-results.ts
@@ -40,6 +40,7 @@ const inserterFactory = (tableName: string) => {
 }
 
 const protocolInsert = inserterFactory('protocols')
+// TODO: update this to use the new protocol.metadata jsonb column
 const protocolDataInsert = inserterFactory('protocol_data')
 const protocolActionInsert = inserterFactory('protocol_actions')
 const protocolResultsInsert = inserterFactory('protocol_results')

--- a/src/migrations/1678817237783-DropProtocolDataTable.ts
+++ b/src/migrations/1678817237783-DropProtocolDataTable.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class DropProtocolDataTable1678817237783 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE "protocol_data"')
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "protocol_data" (
+          "id" bpchar NOT NULL,
+          "protocol_id" bpchar NOT NULL,
+          "created_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          "valid_votes_count" int4,
+          "invalid_votes_count" int4,
+          "machine_votes_count" int4,
+          "voters_count" int4,
+          "nonMachineCastBallotsCount" int4,
+          "machineCastBallotsCount" int4,
+          "castBallotsCount" int4,
+          "partyNonMachineVotesCount" int4,
+          "partyMachineVotesCount" int4,
+          "partyValidVotesCount" int4,
+          CONSTRAINT "protocol_data_protocol_id_fkey" FOREIGN KEY ("protocol_id") REFERENCES "public"."protocols"("id"),
+          PRIMARY KEY ("id")
+      );`,
+    )
+  }
+}


### PR DESCRIPTION
Oт известно време вече, ползваме колоната `protocols.metadata` в `jsonb` формат.

`ProtocolData` се използва само като `ValueObject` и се напасва в `ProtocolDto`, не е entity както беше преди.