### PR TITLE
Достъп до протокол/сигнал без регистрация, но с парола

### DIFF
--- a/src/auth/decorators/allow-only-firebase-user.decorator.ts
+++ b/src/auth/decorators/allow-only-firebase-user.decorator.ts
@@ -1,6 +1,0 @@
-import { SetMetadata } from '@nestjs/common'
-
-export const ALLOW_ONLY_FIREBASE_USER = 'allowOnlyFirebaseUser'
-// Set @AllowOnlyFirebaseUser() to any route which should bypass user exists in db check
-export const AllowOnlyFirebaseUser = () =>
-  SetMetadata(ALLOW_ONLY_FIREBASE_USER, true)

--- a/src/auth/decorators/index.ts
+++ b/src/auth/decorators/index.ts
@@ -1,4 +1,3 @@
-export * from './allow-only-firebase-user.decorator'
 export * from './ApiFirebaseAuth.decorator'
 export * from './inject-firebase-user.decorator'
 export * from './inject-user.decorator'

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1,6 +1,7 @@
 import {
   AbilityBuilder,
   ExtractSubjectType,
+  FieldMatcher,
   InferSubjects,
   MatchConditions,
   PureAbility,
@@ -73,6 +74,7 @@ export type AppAbility = PureAbility<[Actions, Subjects], MatchConditions>
 const lambdaMatcher = (matchConditions: MatchConditions) => matchConditions
 const detectSubjectType = (object: object) =>
   object.constructor as ExtractSubjectType<InferSubjects<Subjects>>
+const fieldMatcher: FieldMatcher = (fields) => (field) => fields.includes(field)
 
 @Injectable()
 export class CaslAbilityFactory {
@@ -104,6 +106,7 @@ export class CaslAbilityFactory {
       return build({
         conditionsMatcher: lambdaMatcher,
         detectSubjectType,
+        fieldMatcher,
       })
     }
 
@@ -151,7 +154,7 @@ export class CaslAbilityFactory {
     if (user.hasRole(Role.Validator) || user.hasRole(Role.Admin)) {
       can(Action.Read, [Protocol, ProtocolResult])
       can(Action.Create, [ProtocolResult])
-      can(Action.Update, Protocol, ['status'])
+      can(Action.Update, Protocol)
       // Can see the organization of the user submitted the protocol
       can(Action.Read, User, ['organization'])
       // TODO: allow reading only the data of the submitter, not the organization of all users
@@ -181,6 +184,7 @@ export class CaslAbilityFactory {
     return build({
       conditionsMatcher: lambdaMatcher,
       detectSubjectType,
+      fieldMatcher,
     })
   }
 }

--- a/src/firebase/auth/passport-firebase.strategy.ts
+++ b/src/firebase/auth/passport-firebase.strategy.ts
@@ -76,7 +76,7 @@ export class FirebaseAuthStrategy extends PassportStrategy(
     decodedIdToken: FirebaseUser,
     req?: Request,
   ): void {
-    const result: FirebaseUser = this.passReqToCallback
+    const result: any = this.passReqToCallback
       ? this.validate(decodedIdToken, req)
       : this.validate(decodedIdToken)
 

--- a/src/migrations/1679015326884-AddSecretToProtocolsAndViolations.ts
+++ b/src/migrations/1679015326884-AddSecretToProtocolsAndViolations.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddSecretToProtocolsAndViolations1679015326884
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "protocols" ADD "secret" varchar DEFAULT NULL`,
+    )
+    await queryRunner.query(
+      `ALTER TABLE "violations" ADD "secret" varchar DEFAULT NULL`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "violations" DROP COLUMN "secret"`)
+    await queryRunner.query(`ALTER TABLE "protocols" DROP COLUMN "secret"`)
+  }
+}

--- a/src/protocols/api/protocol.dto.ts
+++ b/src/protocols/api/protocol.dto.ts
@@ -405,6 +405,11 @@ export class ProtocolDto {
   })
   origin: string
 
+  @Expose({
+    groups: ['created'],
+  })
+  secret: string
+
   private author: UserDto
 
   @Expose({ groups: ['protocol.validate'] })

--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -120,6 +120,7 @@ export class ProtocolsController {
     const savedDto = ProtocolDto.fromEntity(savedProtocol, [
       'read',
       'author_read',
+      'created',
     ])
     this.updatePicturesUrl(savedDto)
 

--- a/src/protocols/api/protocols.controller.ts
+++ b/src/protocols/api/protocols.controller.ts
@@ -15,6 +15,7 @@ import {
   HttpStatus,
   Request,
   Patch,
+  ForbiddenException,
 } from '@nestjs/common'
 import { Request as ExpressRequest, Response } from 'express'
 import { paginate, Pagination } from 'nestjs-typeorm-paginate'
@@ -42,7 +43,7 @@ import {
 import { BadRequestException } from '@nestjs/common'
 import { paginationRoute } from 'src/utils/pagination-route'
 import { WorkItemNotFoundError, WorkQueue } from './work-queue.service'
-import { AppAbility } from 'src/casl/casl-ability.factory'
+import { AppAbility, CaslAbilityFactory } from 'src/casl/casl-ability.factory'
 import { Public } from 'src/auth/decorators'
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler'
 
@@ -53,6 +54,7 @@ export class ProtocolsController {
     @Inject(PicturesUrlGenerator)
     private readonly urlGenerator: PicturesUrlGenerator,
     private readonly workQueue: WorkQueue,
+    private readonly caslAbilityFactory: CaslAbilityFactory,
   ) {}
 
   @Get()
@@ -232,11 +234,18 @@ export class ProtocolsController {
   }
 
   @Get(':id')
+  @Public()
   @HttpCode(200)
-  @UseGuards(PoliciesGuard)
-  @CheckPolicies((ability: AppAbility) => ability.can(Action.Read, Protocol))
-  async get(@Param('id') id: string): Promise<ProtocolDto> {
+  async get(
+    @Param('id') id: string,
+    @InjectUser() user?: User,
+    @Query('secret') secret?: string,
+  ): Promise<ProtocolDto> {
+    const ability = this.caslAbilityFactory.createForUser(user)
     const protocol = await this.repo.findOneOrFail(id)
+    if (!ability.can(Action.Read, protocol) && secret !== protocol.secret) {
+      throw new ForbiddenException()
+    }
     const dto = ProtocolDto.fromEntity(protocol, [
       'read',
       'protocol.validate',

--- a/src/protocols/entities/protocol.entity.ts
+++ b/src/protocols/entities/protocol.entity.ts
@@ -9,6 +9,7 @@ import {
   PrimaryColumn,
 } from 'typeorm'
 import { ulid } from 'ulid'
+import { randomBytes } from 'crypto'
 import { ProtocolAction, ProtocolActionType } from './protocol-action.entity'
 import { ProtocolResult } from './protocol-result.entity'
 import { Section } from '../../sections/entities'
@@ -107,6 +108,9 @@ export class Protocol {
   @Column('jsonb')
   metadata: ProtocolData
 
+  @Column({ type: 'varchar' })
+  secret: string
+
   @ManyToOne(() => Section, (section) => section.protocols, { eager: true })
   section?: Section
 
@@ -161,6 +165,10 @@ export class Protocol {
 
   @OneToMany(() => Protocol, (protocol: Protocol): Protocol => protocol.parent)
   children: Protocol[]
+
+  public constructor() {
+    this.secret = randomBytes(8).toString('base64')
+  }
 
   public getResults(): ProtocolResult[] {
     return this.results || []

--- a/src/users/api/registration.service.ts
+++ b/src/users/api/registration.service.ts
@@ -18,6 +18,13 @@ export default class RegistrationService {
     firebaseUser: FirebaseUser | null,
     userDto: UserDto,
   ): Promise<User> {
+    if (!firebaseUser) {
+      throw new RegistrationError(
+        'RegistrationForbiddenError',
+        'Trying to sign up without a firebase auth token',
+      )
+    }
+
     const userSignup = userDto.toEntity()
 
     if (userSignup.firebaseUid !== firebaseUser.uid) {

--- a/src/users/api/users.controller.ts
+++ b/src/users/api/users.controller.ts
@@ -23,11 +23,7 @@ import { CheckPolicies } from 'src/casl/check-policies.decorator'
 import { PoliciesGuard } from 'src/casl/policies.guard'
 import { FirebaseUser } from 'src/firebase'
 import { paginationRoute } from 'src/utils/pagination-route'
-import {
-  AllowOnlyFirebaseUser,
-  InjectFirebaseUser,
-  InjectUser,
-} from '../../auth/decorators'
+import { InjectFirebaseUser, InjectUser, Public } from '../../auth/decorators'
 import { User } from '../entities'
 import { UsersRepository } from '../entities/users.repository'
 import RegistrationService, { RegistrationError } from './registration.service'
@@ -43,7 +39,7 @@ export class UsersController {
   ) {}
 
   @Post()
-  @AllowOnlyFirebaseUser()
+  @Public()
   @HttpCode(201)
   @UsePipes(
     new ValidationPipe({
@@ -54,7 +50,7 @@ export class UsersController {
   )
   async create(
     @Body() userDto: UserDto,
-    @InjectFirebaseUser() firebaseUser: FirebaseUser,
+    @InjectFirebaseUser() firebaseUser: FirebaseUser | null,
     @InjectUser() authUser: User | undefined,
   ): Promise<UserDto> {
     try {

--- a/src/violations/api/violation.dto.ts
+++ b/src/violations/api/violation.dto.ts
@@ -114,6 +114,11 @@ export class ViolationDto {
   @MaxLength(2000, { groups: ['isPublishedUpdate'] })
   publishedText: string
 
+  @Expose({
+    groups: ['created'],
+  })
+  secret: string
+
   createdAt: Date
 
   public toEntity(): Violation {

--- a/src/violations/api/violations.controller.ts
+++ b/src/violations/api/violations.controller.ts
@@ -136,8 +136,10 @@ export default class ViolationsController {
     const canManageViolation = ability.can(Action.Manage, violation)
     return this.processViolation(
       violation,
-      canManageViolation || canAccessOwnViolation
+      canManageViolation
         ? ['read', 'violation.process', 'author_read']
+        : canAccessOwnViolation
+        ? ['read']
         : [ViolationDto.FEED],
     )
   }

--- a/src/violations/api/violations.controller.ts
+++ b/src/violations/api/violations.controller.ts
@@ -86,9 +86,10 @@ export default class ViolationsController {
     @Body() violationDto: ViolationDto,
     @InjectUser() user?: User,
   ): Promise<ViolationDto> {
-    const violation = violationDto.toEntity()
-    violation.setReceivedStatus(user)
-    return this.processViolation(await this.repo.save(violation))
+    return this.processViolation(
+      await this.repo.save(violationDto.toEntity().setReceivedStatus(user)),
+      ['read', 'violation.process', 'author_read', 'created'],
+    )
   }
 
   @Public()
@@ -187,7 +188,7 @@ export default class ViolationsController {
   }
 
   private updatePicturesUrl(violationDto: ViolationDto) {
-    violationDto.pictures.forEach(
+    violationDto.pictures?.forEach(
       (picture: PictureDto) =>
         (picture.url = this.urlGenerator.getUrl(picture)),
     )

--- a/src/violations/entities/violation.entity.ts
+++ b/src/violations/entities/violation.entity.ts
@@ -105,12 +105,14 @@ export class Violation {
     return this.updates || []
   }
 
-  setReceivedStatus(sender?: User): void {
+  setReceivedStatus(sender?: User): Violation {
     if (this.status) {
       throw new ViolationStatusException(this, ViolationStatus.RECEIVED)
     }
     this.status = ViolationStatus.RECEIVED
     this.addUpdate(ViolationUpdate.createSendUpdate(sender))
+
+    return this
   }
 
   assign(actor: User, assignees: User[]): void {

--- a/src/violations/entities/violation.entity.ts
+++ b/src/violations/entities/violation.entity.ts
@@ -9,6 +9,7 @@ import {
   PrimaryColumn,
 } from 'typeorm'
 import { ulid } from 'ulid'
+import { randomBytes } from 'crypto'
 import { Section, Town } from '../../sections/entities'
 import { Picture } from '../../pictures/entities/picture.entity'
 import { User } from '../../users/entities'
@@ -44,6 +45,9 @@ export class Violation {
 
   @Column({ type: 'varchar' })
   publishedText: string
+
+  @Column({ type: 'varchar' })
+  secret: string
 
   @ManyToOne(() => Section, (section) => section.violations)
   section?: Section
@@ -86,6 +90,10 @@ export class Violation {
     },
   )
   comments: ViolationComment[]
+
+  public constructor() {
+    this.secret = randomBytes(8).toString('base64')
+  }
 
   getAuthor(): User {
     return this.updates.find(


### PR DESCRIPTION
Свързано с ti-broish/results#86

С тези промени, след изпращане на протокол или сигнал, в отговора от сървъра ще се съдържа парола в `secret` полето. Тази парола е достъпна само и единствено непосредствено след създаването на протокола/сигнала.

Тази парола може да бъде запазена в `localStorage` и да се използва за достъпване на протокол или сигнал.

Така протоколите и сигналите са защитени, но все пак могат да бъдат достъпени използвайки запазената парола за съответния протокол/сигнал и авторът може да проследи статуса след като са ги подали.

`GET /protocols/:protocol?secret=:secret`
`GET /violations/:violation?secret=:secret`