### PR TITLE
Add video violation type

### DIFF
--- a/src/migrations/1713520000000-AddTypeToViolations.ts
+++ b/src/migrations/1713520000000-AddTypeToViolations.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddTypeToViolations1713520000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "violations" ADD "type" varchar NOT NULL DEFAULT 'standard'`,
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "violations" DROP COLUMN "type"`)
+  }
+}

--- a/src/violations/api/violation.dto.ts
+++ b/src/violations/api/violation.dto.ts
@@ -10,6 +10,7 @@ import {
   IsArray,
   IsBoolean,
   IsEmail,
+  IsEnum,
   IsNotEmpty,
   IsOptional,
   IsPhoneNumber,
@@ -21,7 +22,11 @@ import {
 } from 'class-validator'
 import { SectionDto } from '../../sections/api/section.dto'
 import { PictureDto } from '../../pictures/api/picture.dto'
-import { Violation, ViolationStatus } from '../entities/violation.entity'
+import {
+  Violation,
+  ViolationStatus,
+  ViolationType,
+} from '../entities/violation.entity'
 import { TownDto } from '../../sections/api/town.dto'
 import { UserDto } from 'src/users/api/user.dto'
 import { ViolationUpdateDto } from './violation-update.dto'
@@ -41,6 +46,11 @@ export class ViolationDto {
 
   @Expose({ groups: ['read', ViolationDto.FEED] })
   id: string
+
+  @Expose({ groups: ['read', 'create', ViolationDto.FEED] })
+  @IsOptional({ groups: ['create'] })
+  @IsEnum(ViolationType, { groups: ['create'] })
+  type: ViolationType
 
   @Expose({ groups: ['read', 'create', ViolationDto.FEED] })
   @Type(() => SectionDto)

--- a/src/violations/api/violations-filters.dto.ts
+++ b/src/violations/api/violations-filters.dto.ts
@@ -9,7 +9,7 @@ import {
 } from 'class-validator'
 import { IsTownExists } from 'src/sections/api/town-exists.constraint'
 import { PageDTO } from 'src/utils/page.dto'
-import { ViolationStatus } from '../entities/violation.entity'
+import { ViolationStatus, ViolationType } from '../entities/violation.entity'
 
 export class ViolationsFilters extends PageDTO {
   @IsOptional()
@@ -54,4 +54,9 @@ export class ViolationsFilters extends PageDTO {
   @IsOptional()
   @IsBooleanString()
   published: boolean
+
+  @IsOptional()
+  @IsString()
+  @IsEnum(ViolationType)
+  type: ViolationType
 }

--- a/src/violations/entities/violation.entity.ts
+++ b/src/violations/entities/violation.entity.ts
@@ -31,12 +31,20 @@ export enum ViolationStatus {
   REJECTED = 'rejected',
 }
 
+export enum ViolationType {
+  STANDARD = 'standard',
+  VIDEO = 'video',
+}
+
 @Entity('violations', { orderBy: { id: 'DESC' } })
 export class Violation {
   @PrimaryColumn('char', {
     length: 26,
   })
   id: string = ulid()
+
+  @Column({ type: 'varchar', default: ViolationType.STANDARD })
+  type: ViolationType
 
   @Column({ type: 'text' })
   description: string

--- a/src/violations/entities/violations.repository.ts
+++ b/src/violations/entities/violations.repository.ts
@@ -233,6 +233,10 @@ export class ViolationsRepository {
       })
     }
 
+    if (filters.type) {
+      qb.andWhere('violation.type = :type', { type: filters.type })
+    }
+
     return qb
   }
 
@@ -300,6 +304,10 @@ export class ViolationsRepository {
       qb.andWhere('violation.isPublished = :published', {
         published: filters.published,
       })
+    }
+
+    if (filters.type) {
+      qb.andWhere('violation.type = :type', { type: filters.type })
     }
 
     return qb.getCount()


### PR DESCRIPTION
## Summary
- Add `ViolationType` enum (`standard`, `video`) to the Violation entity with a new `type` column
- Expose `type` in DTOs for read/create/feed groups with `@IsEnum` validation
- Add optional `type` filter to `ViolationsFilters` for admin filtering
- Add `type` filter to `queryBuilderWithFilters()` and `countWithFilters()` in the repository
- Database migration: `ALTER TABLE violations ADD type varchar DEFAULT 'standard'`

## Test plan
- [ ] Run migration on staging database
- [ ] Create a standard violation via API — verify type defaults to `standard`
- [ ] Create a video violation via API with `type: "video"` — verify it's stored correctly
- [ ] Filter violations by type in admin — verify correct results
- [ ] Verify backward compatibility with existing violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)